### PR TITLE
KC-5917 KC-5968 KC-5966

### DIFF
--- a/docs/source/api.yaml
+++ b/docs/source/api.yaml
@@ -36,10 +36,16 @@ tags:
       Note that these permissions are distinct from system permission which
       control things like which Groups can do things like create Data Sets,
       setup Transforms etc.
+    externalDocs:
+      description: Automation Guide
+      url: automation/intro.rst
   - name: System Permissions
     description: |
       Deprecated. Please see Automation Guide for Thrift API usage.
       Control access to system functionality.
+    externalDocs:
+      description: Automation Guide
+      url: automation/intro.rst
   - name: Indexing Policies
     description: >
       Deprecated. Please see Automation Guide for Thrift API usage.
@@ -53,6 +59,9 @@ tags:
 
       The set of available indexes affects which kinds of interactive queries
       Koverse can support.
+    externalDocs:
+      description: Automation Guide
+      url: automation/intro.rst
   - name: Query
     description: >
       Interactively query Data Sets.
@@ -73,18 +82,30 @@ tags:
 
       Source types specify which parameters are available for each type of
       Source.
+    externalDocs:
+      description: Automation Guide
+      url: automation/intro.rst
   - name: Sources
     description: |
       Deprecated. Please see Automation Guide for Thrift API usage.
       Sources are external data systems from which Koverse can ingest data.
+    externalDocs:
+      description: Automation Guide
+      url: automation/intro.rst
   - name: Import Flows
     description: |
       Deprecated. Please see Automation Guide for Thrift API usage.
       Configure a Source to import external data to a specific Data Set.
+    externalDocs:
+      description: Automation Guide
+      url: automation/intro.rst
   - name: Normalizations
     description: |
       Deprecated. Please see Automation Guide for Thrift API usage.
       Normalizations allow data to be modified as it is imported.
+    externalDocs:
+      description: Automation Guide
+      url: automation/intro.rst
   - name: Import Jobs
     description: >
       Deprecated. Please see Automation Guide for Thrift API usage.
@@ -104,6 +125,9 @@ tags:
 
 
       Jobs can be started or shutdown via these methods.
+    externalDocs:
+      description: Automation Guide
+      url: automation/intro.rst
   - name: Import Schedules
     description: >
       Deprecated. Please see Automation Guide for Thrift API usage.
@@ -115,6 +139,9 @@ tags:
 
       Import Jobs can still be created for Import Flows without schedules on an
       on-demand basis.
+    externalDocs:
+      description: Automation Guide
+      url: automation/intro.rst
   - name: Transform Types
     description: >
       Deprecated. Please see Automation Guide for Thrift API usage.
@@ -123,12 +150,18 @@ tags:
 
       Transform types specify which parameters are available for each type of
       Transform.
+    externalDocs:
+      description: Automation Guide
+      url: automation/intro.rst
   - name: Transforms
     description: >
       Deprecated. Please see Automation Guide for Thrift API usage.
 
       Setup a partiular Transform Type to transform one or more data sets into a
       new Data Set.
+    externalDocs:
+      description: Automation Guide
+      url: automation/intro.rst
   - name: Transform Jobs
     description: >
       Deprecated. Please see Automation Guide for Thrift API usage.
@@ -148,6 +181,9 @@ tags:
 
 
       Jobs can be started or shutdown via these methods.
+    externalDocs:
+      description: Automation Guide
+      url: automation/intro.rst
   - name: Transform Schedules
     description: >
       Deprecated. Please see Automation Guide for Thrift API usage.
@@ -160,16 +196,25 @@ tags:
       Transforms Jobs can still be created for Transforms without schedules on
       an on-demand basis, or automatically as new data is ingested via Import
       Jobs into input Data Sets.
+    externalDocs:
+      description: Automation Guide
+      url: automation/intro.rst
   - name: Sink Types
     description: |
       Deprecated. Please see Automation Guide for Thrift API usage.
       List and get available Sink types.
       Sinks are external systems to which Koverse can export data.
+    externalDocs:
+      description: Automation Guide
+      url: automation/intro.rst
   - name: Sinks
     description: |
       Deprecated. Please see Automation Guide for Thrift API usage.
       Create, update, and delete Sinks.
       Sinks are external systems to which Koverse can export data.
+    externalDocs:
+      description: Automation Guide
+      url: automation/intro.rst
   - name: Export Jobs
     description: >
       Deprecated. Please see Automation Guide for Thrift API usage.
@@ -189,6 +234,9 @@ tags:
 
 
       Jobs can be started or shutdown via these methods.
+    externalDocs:
+      description: Automation Guide
+      url: automation/intro.rst
   - name: Sink Schedules
     description: >
       Deprecated. Please see Automation Guide for Thrift API usage.
@@ -232,6 +280,9 @@ tags:
       inteference.
 
       In some cases a blocked job can be unblocked so it can proceed.
+    externalDocs:
+      description: Automation Guide
+      url: automation/intro.rst
 definitions:
   500servererror:
     type: string

--- a/docs/source/api.yaml
+++ b/docs/source/api.yaml
@@ -653,7 +653,39 @@ definitions:
       flatSchema: true
       recordMatchCountLimited: false
       records:
-        - $ref: '#/definitions/record/example'
+        - recordId: null
+          collectionId: movies_20171107_172745_048
+          securityLabel: ''
+          value:
+            plot_keywords: african american|code|dog|pigeon|samurai
+            country: France
+            aspect_ratio: 1.85
+            actor_3_facebook_likes: 116
+            num_critic_for_reviews: 167
+            color: Color
+            language: English
+            title_year: 1999
+            imdb_score: 7.5
+            duration: 116
+            genres: Action|Crime|Drama|Thriller
+            actor_1_name: Henry Silva
+            director_facebook_likes: 0
+            content_rating: R
+            num_voted_users: 70084
+            gross: 3300230
+            facenumber_in_poster: 1
+            actor_2_name: Gano Grills
+            num_user_for_reviews: 346
+            actor_1_facebook_likes: 251
+            movie_title: Ghost Dog - The Way of the Samurai
+            movie_facebook_likes: 0
+            actor_2_facebook_likes: 147
+            movie_imdb_link: 'http://www.imdb.com/title/tt0165798/?ref_=fn_tt_tt_1'
+            director_name: Jim Jarmusch
+            cast_total_facebook_likes: 675
+            actor_3_name: Richard Portnow
+          matchValues: null
+          isMatch: false
       successful: true
       errorMessage: ''
   dataSetSchemas:
@@ -933,46 +965,19 @@ definitions:
         type: string
       securityLabel:
         type: string
-      value:
+      fields:
         type: object
         description: >
           An object containing the fields and values within this record. The
-          structure of this object will vary from data set to data set. Here we
-          include 'fieldOne', 'fieldTwo', etc. just as an example.
+          structure of this object will vary from data set to data set.
     example:
-      recordId: null
-      collectionId: movies_20171107_172745_048
+      recordId: 1
+      collectionId: wiki_20191101_135232_062
       securityLabel: ''
-      value:
-        plot_keywords: african american|code|dog|pigeon|samurai
-        country: France
-        aspect_ratio: 1.85
-        actor_3_facebook_likes: 116
-        num_critic_for_reviews: 167
-        color: Color
-        language: English
-        title_year: 1999
-        imdb_score: 7.5
-        duration: 116
-        genres: Action|Crime|Drama|Thriller
-        actor_1_name: Henry Silva
-        director_facebook_likes: 0
-        content_rating: R
-        num_voted_users: 70084
-        gross: 3300230
-        facenumber_in_poster: 1
-        actor_2_name: Gano Grills
-        num_user_for_reviews: 346
-        actor_1_facebook_likes: 251
-        movie_title: Ghost Dog - The Way of the Samurai
-        movie_facebook_likes: 0
-        actor_2_facebook_likes: 147
-        movie_imdb_link: 'http://www.imdb.com/title/tt0165798/?ref_=fn_tt_tt_1'
-        director_name: Jim Jarmusch
-        cast_total_facebook_likes: 675
-        actor_3_name: Richard Portnow
-      matchValues: null
-      isMatch: false
+      fields:
+        id: 576
+        name: bob
+        age: 35
   sink:
     type: object
     properties:
@@ -2541,7 +2546,7 @@ paths:
       - $ref: '#/parameters/recordId'
     get:
       summary: Get
-      operationId: getRecordById
+      operationId: getRecord
       tags:
         - Records
       parameters:
@@ -2554,7 +2559,8 @@ paths:
           in: query
           required: true
       description: >
-        Get a single record by data set id and record id.
+        Get a single record by data set id and record id. (Note: recordIds may
+        have a delimiter that is not valid json)
 
 
         Note that the Record ID must be known in order to use this method.
@@ -2579,8 +2585,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/definitions/record'
-        '404':
-          description: If record not found.
         '500':
           description: Returns server error if recordId or dataSetId are missing.
           schema:
@@ -3181,7 +3185,7 @@ paths:
           description: Returns the transform type
           schema:
             $ref: '#/definitions/transformType'
-  /api/v1/queries/:
+  /api/v1/queries/lucene:
     get:
       summary: Lucene style
       operationId: queryLucene

--- a/docs/source/api.yaml
+++ b/docs/source/api.yaml
@@ -23,9 +23,6 @@ tags:
       List, inspect, and configure masking for data set attributes
   - name: Data Set Permissions
     description: >
-      Deprecated. Please see Automation Guide for Thrift API usage.
-
-
       Control access to data in Data Sets.
 
 
@@ -37,19 +34,16 @@ tags:
       control things like which Groups can do things like create Data Sets,
       setup Transforms etc.
     externalDocs:
-      description: Automation Guide
-      url: automation/intro.rst
+      description: Deprecated. Please see Automation Guide for API usage.
+      url: dev/automation/automationguide.rst
   - name: System Permissions
     description: |
-      Deprecated. Please see Automation Guide for Thrift API usage.
       Control access to system functionality.
     externalDocs:
-      description: Automation Guide
-      url: automation/intro.rst
+      description: Deprecated. Please see Automation Guide for API usage.
+      url: dev/automation/automationguide.rst
   - name: Indexing Policies
     description: >
-      Deprecated. Please see Automation Guide for Thrift API usage.
-
       Control how Koverse indexes data in a data set.
 
 
@@ -60,8 +54,8 @@ tags:
       The set of available indexes affects which kinds of interactive queries
       Koverse can support.
     externalDocs:
-      description: Automation Guide
-      url: automation/intro.rst
+      description: Deprecated. Please see Automation Guide for API usage.
+      url: dev/automation/automationguide.rst
   - name: Query
     description: >
       Interactively query Data Sets.
@@ -76,40 +70,33 @@ tags:
       Write and retrieve individual records and sets of sample records.
   - name: Source Types
     description: >
-      Deprecated. Please see Automation Guide for Thrift API usage.
-
       List available Source types.
 
       Source types specify which parameters are available for each type of
       Source.
     externalDocs:
-      description: Automation Guide
-      url: automation/intro.rst
+      description: Deprecated. Please see Automation Guide for API usage.
+      url: dev/automation/automationguide.rst
   - name: Sources
     description: |
-      Deprecated. Please see Automation Guide for Thrift API usage.
       Sources are external data systems from which Koverse can ingest data.
     externalDocs:
-      description: Automation Guide
-      url: automation/intro.rst
+      description: Deprecated. Please see Automation Guide for API usage.
+      url: dev/automation/automationguide.rst
   - name: Import Flows
     description: |
-      Deprecated. Please see Automation Guide for Thrift API usage.
       Configure a Source to import external data to a specific Data Set.
     externalDocs:
-      description: Automation Guide
-      url: automation/intro.rst
+      description: Deprecated. Please see Automation Guide for API usage.
+      url: dev/automation/automationguide.rst
   - name: Normalizations
     description: |
-      Deprecated. Please see Automation Guide for Thrift API usage.
       Normalizations allow data to be modified as it is imported.
     externalDocs:
-      description: Automation Guide
-      url: automation/intro.rst
+      description: Deprecated. Please see Automation Guide for API usage.
+      url: dev/automation/automationguide.rst
   - name: Import Jobs
     description: >
-      Deprecated. Please see Automation Guide for Thrift API usage.
-
       Import jobs are used for importing data from an external Source into a
       Data Set.
 
@@ -126,12 +113,10 @@ tags:
 
       Jobs can be started or shutdown via these methods.
     externalDocs:
-      description: Automation Guide
-      url: automation/intro.rst
+      description: Deprecated. Please see Automation Guide for API usage.
+      url: dev/automation/automationguide.rst
   - name: Import Schedules
     description: >
-      Deprecated. Please see Automation Guide for Thrift API usage.
-
       Manage schedules for Import Flows.
 
 
@@ -140,32 +125,26 @@ tags:
       Import Jobs can still be created for Import Flows without schedules on an
       on-demand basis.
     externalDocs:
-      description: Automation Guide
-      url: automation/intro.rst
+      description: Deprecated. Please see Automation Guide for API usage.
+      url: dev/automation/automationguide.rst
   - name: Transform Types
     description: >
-      Deprecated. Please see Automation Guide for Thrift API usage.
-
       Get a list of transforms available in the system.
 
       Transform types specify which parameters are available for each type of
       Transform.
     externalDocs:
-      description: Automation Guide
-      url: automation/intro.rst
+      description: Deprecated. Please see Automation Guide for API usage.
+      url: dev/automation/automationguide.rst
   - name: Transforms
     description: >
-      Deprecated. Please see Automation Guide for Thrift API usage.
-
       Setup a partiular Transform Type to transform one or more data sets into a
       new Data Set.
     externalDocs:
-      description: Automation Guide
-      url: automation/intro.rst
+      description: Deprecated. Please see Automation Guide for API usage.
+      url: dev/automation/automationguide.rst
   - name: Transform Jobs
     description: >
-      Deprecated. Please see Automation Guide for Thrift API usage.
-
       Transform jobs process new data or all data in input Data Sets and write
       out results to an output Data Set.
 
@@ -182,12 +161,10 @@ tags:
 
       Jobs can be started or shutdown via these methods.
     externalDocs:
-      description: Automation Guide
-      url: automation/intro.rst
+      description: Deprecated. Please see Automation Guide for API usage.
+      url: dev/automation/automationguide.rst
   - name: Transform Schedules
     description: >
-      Deprecated. Please see Automation Guide for Thrift API usage.
-
       Manage schedules for Transforms.
 
 
@@ -197,28 +174,24 @@ tags:
       an on-demand basis, or automatically as new data is ingested via Import
       Jobs into input Data Sets.
     externalDocs:
-      description: Automation Guide
-      url: automation/intro.rst
+      description: Deprecated. Please see Automation Guide for API usage.
+      url: dev/automation/automationguide.rst
   - name: Sink Types
     description: |
-      Deprecated. Please see Automation Guide for Thrift API usage.
       List and get available Sink types.
       Sinks are external systems to which Koverse can export data.
     externalDocs:
-      description: Automation Guide
-      url: automation/intro.rst
+      description: Deprecated. Please see Automation Guide for API usage.
+      url: dev/automation/automationguide.rst
   - name: Sinks
     description: |
-      Deprecated. Please see Automation Guide for Thrift API usage.
       Create, update, and delete Sinks.
       Sinks are external systems to which Koverse can export data.
     externalDocs:
-      description: Automation Guide
-      url: automation/intro.rst
+      description: Deprecated. Please see Automation Guide for API usage.
+      url: dev/automation/automationguide.rst
   - name: Export Jobs
     description: >
-      Deprecated. Please see Automation Guide for Thrift API usage.
-
       Export jobs write new data or all data in input Data Sets to an external
       Sink.
 
@@ -235,12 +208,10 @@ tags:
 
       Jobs can be started or shutdown via these methods.
     externalDocs:
-      description: Automation Guide
-      url: automation/intro.rst
+      description: Deprecated. Please see Automation Guide for API usage.
+      url: dev/automation/automationguide.rst
   - name: Sink Schedules
     description: >
-      Deprecated. Please see Automation Guide for Thrift API usage.
-
       Manage schedules for exporting to Sinks
 
 
@@ -248,10 +219,11 @@ tags:
 
       Export Jobs can still be created for Sinks without schedules on an
       on-demand basis or automatically as new data appears in input Data Sets.
+    externalDocs:
+      description: Deprecated. Please see Automation Guide for API usage.
+      url: dev/automation/automationguide.rst
   - name: Jobs
     description: >
-      Deprecated. Please see Automation Guide for Thrift API usage.
-
       Start, monitor, and cancel data processing jobs.
 
 
@@ -281,8 +253,8 @@ tags:
 
       In some cases a blocked job can be unblocked so it can proceed.
     externalDocs:
-      description: Automation Guide
-      url: automation/intro.rst
+      description: Deprecated. Please see Automation Guide for API usage.
+      url: dev/automation/automationguide.rst
 definitions:
   500servererror:
     type: string

--- a/docs/source/api.yaml
+++ b/docs/source/api.yaml
@@ -35,13 +35,13 @@ tags:
       setup Transforms etc.
     externalDocs:
       description: Deprecated. Please see Automation Guide for API usage.
-      url: dev/automation/automationguide.rst
+      url: dev/automation/automationguide.html
   - name: System Permissions
     description: |
       Control access to system functionality.
     externalDocs:
       description: Deprecated. Please see Automation Guide for API usage.
-      url: dev/automation/automationguide.rst
+      url: dev/automation/automationguide.html
   - name: Indexing Policies
     description: >
       Control how Koverse indexes data in a data set.
@@ -55,7 +55,7 @@ tags:
       Koverse can support.
     externalDocs:
       description: Deprecated. Please see Automation Guide for API usage.
-      url: dev/automation/automationguide.rst
+      url: dev/automation/automationguide.html
   - name: Query
     description: >
       Interactively query Data Sets.
@@ -76,25 +76,25 @@ tags:
       Source.
     externalDocs:
       description: Deprecated. Please see Automation Guide for API usage.
-      url: dev/automation/automationguide.rst
+      url: dev/automation/automationguide.html
   - name: Sources
     description: |
       Sources are external data systems from which Koverse can ingest data.
     externalDocs:
       description: Deprecated. Please see Automation Guide for API usage.
-      url: dev/automation/automationguide.rst
+      url: dev/automation/automationguide.html
   - name: Import Flows
     description: |
       Configure a Source to import external data to a specific Data Set.
     externalDocs:
       description: Deprecated. Please see Automation Guide for API usage.
-      url: dev/automation/automationguide.rst
+      url: dev/automation/automationguide.html
   - name: Normalizations
     description: |
       Normalizations allow data to be modified as it is imported.
     externalDocs:
       description: Deprecated. Please see Automation Guide for API usage.
-      url: dev/automation/automationguide.rst
+      url: dev/automation/automationguide.html
   - name: Import Jobs
     description: >
       Import jobs are used for importing data from an external Source into a
@@ -114,7 +114,7 @@ tags:
       Jobs can be started or shutdown via these methods.
     externalDocs:
       description: Deprecated. Please see Automation Guide for API usage.
-      url: dev/automation/automationguide.rst
+      url: dev/automation/automationguide.html
   - name: Import Schedules
     description: >
       Manage schedules for Import Flows.
@@ -126,7 +126,7 @@ tags:
       on-demand basis.
     externalDocs:
       description: Deprecated. Please see Automation Guide for API usage.
-      url: dev/automation/automationguide.rst
+      url: dev/automation/automationguide.html
   - name: Transform Types
     description: >
       Get a list of transforms available in the system.
@@ -135,14 +135,14 @@ tags:
       Transform.
     externalDocs:
       description: Deprecated. Please see Automation Guide for API usage.
-      url: dev/automation/automationguide.rst
+      url: dev/automation/automationguide.html
   - name: Transforms
     description: >
       Setup a partiular Transform Type to transform one or more data sets into a
       new Data Set.
     externalDocs:
       description: Deprecated. Please see Automation Guide for API usage.
-      url: dev/automation/automationguide.rst
+      url: dev/automation/automationguide.html
   - name: Transform Jobs
     description: >
       Transform jobs process new data or all data in input Data Sets and write
@@ -162,7 +162,7 @@ tags:
       Jobs can be started or shutdown via these methods.
     externalDocs:
       description: Deprecated. Please see Automation Guide for API usage.
-      url: dev/automation/automationguide.rst
+      url: dev/automation/automationguide.html
   - name: Transform Schedules
     description: >
       Manage schedules for Transforms.
@@ -175,21 +175,21 @@ tags:
       Jobs into input Data Sets.
     externalDocs:
       description: Deprecated. Please see Automation Guide for API usage.
-      url: dev/automation/automationguide.rst
+      url: dev/automation/automationguide.html
   - name: Sink Types
     description: |
       List and get available Sink types.
       Sinks are external systems to which Koverse can export data.
     externalDocs:
       description: Deprecated. Please see Automation Guide for API usage.
-      url: dev/automation/automationguide.rst
+      url: dev/automation/automationguide.html
   - name: Sinks
     description: |
       Create, update, and delete Sinks.
       Sinks are external systems to which Koverse can export data.
     externalDocs:
       description: Deprecated. Please see Automation Guide for API usage.
-      url: dev/automation/automationguide.rst
+      url: dev/automation/automationguide.html
   - name: Export Jobs
     description: >
       Export jobs write new data or all data in input Data Sets to an external
@@ -209,7 +209,7 @@ tags:
       Jobs can be started or shutdown via these methods.
     externalDocs:
       description: Deprecated. Please see Automation Guide for API usage.
-      url: dev/automation/automationguide.rst
+      url: dev/automation/automationguide.html
   - name: Sink Schedules
     description: >
       Manage schedules for exporting to Sinks
@@ -221,7 +221,7 @@ tags:
       on-demand basis or automatically as new data appears in input Data Sets.
     externalDocs:
       description: Deprecated. Please see Automation Guide for API usage.
-      url: dev/automation/automationguide.rst
+      url: dev/automation/automationguide.html
   - name: Jobs
     description: >
       Start, monitor, and cancel data processing jobs.
@@ -254,7 +254,7 @@ tags:
       In some cases a blocked job can be unblocked so it can proceed.
     externalDocs:
       description: Deprecated. Please see Automation Guide for API usage.
-      url: dev/automation/automationguide.rst
+      url: dev/automation/automationguide.html
 definitions:
   500servererror:
     type: string

--- a/docs/source/api.yaml
+++ b/docs/source/api.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 3.0
+  version: '3.0'
   title: Koverse REST API
   description: |
     Specification for interacting with the Koverse Rest API
@@ -23,6 +23,9 @@ tags:
       List, inspect, and configure masking for data set attributes
   - name: Data Set Permissions
     description: >
+      Deprecated. Please see Automation Guide for Thrift API usage.
+
+
       Control access to data in Data Sets.
 
 
@@ -35,9 +38,12 @@ tags:
       setup Transforms etc.
   - name: System Permissions
     description: |
+      Deprecated. Please see Automation Guide for Thrift API usage.
       Control access to system functionality.
   - name: Indexing Policies
     description: >
+      Deprecated. Please see Automation Guide for Thrift API usage.
+
       Control how Koverse indexes data in a data set.
 
 
@@ -61,21 +67,28 @@ tags:
       Write and retrieve individual records and sets of sample records.
   - name: Source Types
     description: >
+      Deprecated. Please see Automation Guide for Thrift API usage.
+
       List available Source types.
 
       Source types specify which parameters are available for each type of
       Source.
   - name: Sources
     description: |
+      Deprecated. Please see Automation Guide for Thrift API usage.
       Sources are external data systems from which Koverse can ingest data.
   - name: Import Flows
     description: |
+      Deprecated. Please see Automation Guide for Thrift API usage.
       Configure a Source to import external data to a specific Data Set.
   - name: Normalizations
     description: |
+      Deprecated. Please see Automation Guide for Thrift API usage.
       Normalizations allow data to be modified as it is imported.
   - name: Import Jobs
     description: >
+      Deprecated. Please see Automation Guide for Thrift API usage.
+
       Import jobs are used for importing data from an external Source into a
       Data Set.
 
@@ -93,6 +106,8 @@ tags:
       Jobs can be started or shutdown via these methods.
   - name: Import Schedules
     description: >
+      Deprecated. Please see Automation Guide for Thrift API usage.
+
       Manage schedules for Import Flows.
 
 
@@ -102,16 +117,22 @@ tags:
       on-demand basis.
   - name: Transform Types
     description: >
+      Deprecated. Please see Automation Guide for Thrift API usage.
+
       Get a list of transforms available in the system.
 
       Transform types specify which parameters are available for each type of
       Transform.
   - name: Transforms
     description: >
+      Deprecated. Please see Automation Guide for Thrift API usage.
+
       Setup a partiular Transform Type to transform one or more data sets into a
       new Data Set.
   - name: Transform Jobs
     description: >
+      Deprecated. Please see Automation Guide for Thrift API usage.
+
       Transform jobs process new data or all data in input Data Sets and write
       out results to an output Data Set.
 
@@ -129,6 +150,8 @@ tags:
       Jobs can be started or shutdown via these methods.
   - name: Transform Schedules
     description: >
+      Deprecated. Please see Automation Guide for Thrift API usage.
+
       Manage schedules for Transforms.
 
 
@@ -139,14 +162,18 @@ tags:
       Jobs into input Data Sets.
   - name: Sink Types
     description: |
+      Deprecated. Please see Automation Guide for Thrift API usage.
       List and get available Sink types.
       Sinks are external systems to which Koverse can export data.
   - name: Sinks
     description: |
+      Deprecated. Please see Automation Guide for Thrift API usage.
       Create, update, and delete Sinks.
       Sinks are external systems to which Koverse can export data.
   - name: Export Jobs
     description: >
+      Deprecated. Please see Automation Guide for Thrift API usage.
+
       Export jobs write new data or all data in input Data Sets to an external
       Sink.
 
@@ -164,6 +191,8 @@ tags:
       Jobs can be started or shutdown via these methods.
   - name: Sink Schedules
     description: >
+      Deprecated. Please see Automation Guide for Thrift API usage.
+
       Manage schedules for exporting to Sinks
 
 
@@ -173,6 +202,8 @@ tags:
       on-demand basis or automatically as new data appears in input Data Sets.
   - name: Jobs
     description: >
+      Deprecated. Please see Automation Guide for Thrift API usage.
+
       Start, monitor, and cancel data processing jobs.
 
 
@@ -202,6 +233,11 @@ tags:
 
       In some cases a blocked job can be unblocked so it can proceed.
 definitions:
+  500servererror:
+    type: string
+    description: |
+      An error has occurred.
+    example: '500 Server Error, No data sets found.'
   apiClient:
     type: object
     required:
@@ -1296,6 +1332,13 @@ parameters:
     description: ID of the job
     required: true
     type: string
+  maxStringValueLength:
+    name: maxStringValueLength
+    in: query
+    description: 'length to truncate string values, default is -1 for ''no truncate'''
+    required: false
+    type: integer
+    format: int64
   normalizationId:
     name: normalizationId
     in: path
@@ -1430,7 +1473,8 @@ parameters:
         - query
       description: >
         This object contains the parameters used to issue a query against one or
-        more data sets. The query is defined as a JSON string
+        more data sets. The query is defined as a JSON string. The query will
+        return an empty array '[]' if no records are found.
       properties:
         collectionNames:
           type: array
@@ -1559,6 +1603,13 @@ parameters:
     type: string
     enum:
       - 2.2
+  removeByteArrayFieldValues:
+    name: removeByteArrayFieldValues
+    in: query
+    description: |
+      Removes values with datatype byte array
+    required: false
+    type: boolean
   sink:
     name: sink
     in: body
@@ -1653,6 +1704,7 @@ paths:
             $ref: '#/definitions/logout'
   /api/v1/applications:
     get:
+      deprecated: true
       summary: List
       operationId: findApplications
       tags:
@@ -1667,9 +1719,8 @@ paths:
             type: array
             items:
               $ref: '#/definitions/apiClient'
-        '500':
-          description: Server Error - If data set not found message will read 'Could not find database object in
     post:
+      deprecated: true
       summary: Create
       operationId: createApplication
       tags:
@@ -1684,7 +1735,7 @@ paths:
           schema:
             $ref: '#/definitions/apiClient'
       responses:
-        '201':
+        '200':
           description: Returns the newly created Application
           schema:
             $ref: '#/definitions/apiClient'
@@ -1692,6 +1743,7 @@ paths:
     parameters:
       - $ref: '#/parameters/applicationId'
     get:
+      deprecated: true
       summary: Get
       description: |
         Get the details about the given application.
@@ -1704,6 +1756,7 @@ paths:
           schema:
             $ref: '#/definitions/apiClient'
     put:
+      deprecated: true
       summary: Update
       description: |
         Update the application details.
@@ -1716,6 +1769,7 @@ paths:
           schema:
             $ref: '#/definitions/apiClient'
     delete:
+      deprecated: true
       summary: Delete
       description: |
         Delete the application specified by id.
@@ -1736,6 +1790,8 @@ paths:
       description: |
         Get a list of data set metadata objects for all data sets the user is
         authorized to see.
+
+        Call will return an empty list if no data sets were found.
       responses:
         '200':
           description: Returns metadata for all data sets the user is authorized to see
@@ -1743,8 +1799,6 @@ paths:
             type: array
             items:
               $ref: '#/definitions/dataSetMetadata'
-        '500':
-          description: If data set not found message will read 'No content to map to Object due to end of input'
     post:
       summary: Create
       operationId: createDataSet
@@ -1754,8 +1808,9 @@ paths:
         Creates a new empty data set.
 
 
-        Note: This call will fail if there is already a data set with the same
-        name as the requested new data set.
+        Note: This call will succeed if there is already a data set with the
+        same name as the requested new data set. The name will be updated to
+        indicate how many other data sets have that name, such as "Movies (2)".
       parameters:
         - name: body
           in: body
@@ -1764,7 +1819,7 @@ paths:
           schema:
             $ref: '#/definitions/dataSet'
       responses:
-        '201':
+        '200':
           description: Returns the newly created Data Set metadata
           schema:
             $ref: '#/definitions/dataSetMetadata'
@@ -1785,6 +1840,10 @@ paths:
           description: Returns the data set metadata
           schema:
             $ref: '#/definitions/dataSetMetadata'
+        '500':
+          description: Returns server error if no data set is found
+          schema:
+            $ref: '#/definitions/500servererror'
     put:
       summary: Update
       description: |
@@ -1809,6 +1868,12 @@ paths:
           description: Returns the data set metadata with an updated DELETED dataset name.
           schema:
             $ref: '#/definitions/dataSetMetadata'
+        '500':
+          description: >-
+            If data set not found message will read 'No content to map to Object
+            due to end of input'
+          schema:
+            $ref: '#/definitions/500servererror'
   '/api/v1/data-sets/{dataSetId}/attribute-names':
     parameters:
       - $ref: '#/parameters/dataSetId'
@@ -1835,7 +1900,11 @@ paths:
             items:
               type: string
         '500':
-          description: If data set not found message will read 'Internal error processing getDataSetAttributeNames'
+          description: >-
+            If data set not found message will read 'Internal error processing
+            getDataSetAttributeNames'
+          schema:
+            $ref: '#/definitions/500servererror'
   '/api/v1/data-sets/{dataSetId}/attributes':
     parameters:
       - $ref: '#/parameters/dataSetId'
@@ -1857,7 +1926,13 @@ paths:
             type: array
             items:
               $ref: '#/definitions/dataSetAttributes'
-  '/api/v1/data-sets/{datasetId}/clear':
+        '500':
+          description: >-
+            If data set not found message will read 'Could not find database
+            object in method...'
+          schema:
+            $ref: '#/definitions/500servererror'
+  '/api/v1/data-sets/{dataSetId}/clear':
     parameters:
       - $ref: '#/parameters/dataSetId'
     get:
@@ -1872,9 +1947,13 @@ paths:
         command and should be called sparingly.
       responses:
         '200':
-          description: Data was cleared
+          description: 200 OK
         '500':
-          description: If data set not found message will read 'No content to map to Object due to end of input'
+          description: >-
+            If data set not found message will read 'No content to map to Object
+            due to end of input'
+          schema:
+            $ref: '#/definitions/500servererror'
   '/api/v1/data-sets/{dataSetId}/indexingPolicy':
     parameters:
       - $ref: '#/parameters/dataSetId'
@@ -1935,6 +2014,8 @@ paths:
     parameters:
       - $ref: '#/parameters/dataSetId'
       - $ref: '#/parameters/recordStyle'
+      - $ref: '#/parameters/removeByteArrayFieldValues'
+      - $ref: '#/parameters/maxStringValueLength'
     get:
       summary: Get sample records
       operationId: findDataSetRecordsById
@@ -1945,7 +2026,9 @@ paths:
         Returns all the fields and values for a sample of records by data set
         id.
 
-        Note: The recordStyle query parameter defaults to a value of "2.1" which returns a file attachment with the records.
+
+        Note: The recordStyle query parameter defaults to a value of "2.1" which
+        returns a file attachment with the records.
 
         To return json output of records, you must specify the recordStyle query
         parameter "2.2".
@@ -1978,9 +2061,13 @@ paths:
         regenerate that information from data set records.
       responses:
         '200':
-          description: Repair sucessful
+          description: 200 OK
         '500':
-          description: If data set not found message will read 'No content to map to Object due to end of input'
+          description: >-
+            If data set not found message will read 'No content to map to Object
+            due to end of input'
+          schema:
+            $ref: '#/definitions/500servererror'
   '/api/v1/data-sets/{dataSetId}/attributes/masking':
     parameters:
       - $ref: '#/parameters/dataSetId'
@@ -2011,6 +2098,7 @@ paths:
               $ref: '#/definitions/dataSetAttributes'
   /api/v1/import-flows:
     post:
+      deprecated: true
       summary: Create
       operationId: addImportFlow
       tags:
@@ -2037,6 +2125,7 @@ paths:
     parameters:
       - $ref: '#/parameters/importFlowIdPath'
     get:
+      deprecated: true
       summary: Get
       operationId: findImportFlowById
       tags:
@@ -2048,6 +2137,7 @@ paths:
           schema:
             $ref: '#/definitions/importFlow'
     delete:
+      deprecated: true
       summary: Delete
       operationId: deleteImportFlowById
       tags:
@@ -2059,6 +2149,7 @@ paths:
           schema:
             $ref: '#/definitions/importFlow'
     put:
+      deprecated: true
       summary: Update
       operationId: updateImportFlowById
       tags:
@@ -2080,6 +2171,7 @@ paths:
     parameters:
       - $ref: '#/parameters/importFlowIdPath'
     post:
+      deprecated: true
       summary: Start
       operationId: funImportFlowById
       tags:
@@ -2106,6 +2198,7 @@ paths:
     parameters:
       - $ref: '#/parameters/importFlowIdPath'
     get:
+      deprecated: true
       summary: Get for an import flow
       tags:
         - Normalizations
@@ -2120,6 +2213,7 @@ paths:
             items:
               $ref: '#/definitions/normalization'
     post:
+      deprecated: true
       summary: Create
       tags:
         - Normalizations
@@ -2143,6 +2237,7 @@ paths:
       - $ref: '#/parameters/importFlowIdPath'
       - $ref: '#/parameters/normalizationId'
     get:
+      deprecated: true
       summary: Get
       operationId: findNormalizationById
       tags:
@@ -2154,6 +2249,7 @@ paths:
           schema:
             $ref: '#/definitions/normalization'
     put:
+      deprecated: true
       summary: Update
       operationId: updateNormalizationById
       tags:
@@ -2172,6 +2268,7 @@ paths:
           schema:
             $ref: '#/definitions/normalization'
     delete:
+      deprecated: true
       summary: Delete
       operationId: deleteNormalization
       tags:
@@ -2186,6 +2283,7 @@ paths:
     parameters:
       - $ref: '#/parameters/importFlowIdPath'
     get:
+      deprecated: true
       summary: Get by Import Flow
       operationId: findImportSchedules
       tags:
@@ -2203,6 +2301,7 @@ paths:
     parameters:
       - $ref: '#/parameters/sourceId'
     get:
+      deprecated: true
       summary: Get by source
       operationId: findImportFlowBySourceId
       tags:
@@ -2218,6 +2317,7 @@ paths:
     parameters:
       - $ref: '#/parameters/importJobId'
     get:
+      deprecated: true
       summary: Shutdown
       operationId: shutdownImportJobById
       tags:
@@ -2233,6 +2333,7 @@ paths:
     parameters:
       - $ref: '#/parameters/importFlowId'
     post:
+      deprecated: true
       summary: Create
       operationId: addImportSchedule
       tags:
@@ -2255,6 +2356,7 @@ paths:
     parameters:
       - $ref: '#/parameters/importScheduleId'
     get:
+      deprecated: true
       summary: Get
       operationId: findImportScheduleById
       tags:
@@ -2267,6 +2369,7 @@ paths:
           schema:
             $ref: '#/definitions/importSchedule'
     delete:
+      deprecated: true
       summary: Delete
       operationId: deleteImportSchedule
       tags:
@@ -2280,6 +2383,7 @@ paths:
             $ref: '#/definitions/importSchedule'
   /api/v1/jobs:
     get:
+      deprecated: true
       summary: Get active
       operationId: findActiveJobs
       tags:
@@ -2325,6 +2429,7 @@ paths:
           description: Job unblocked
   /api/v1/permissions:
     post:
+      deprecated: true
       summary: Create
       operationId: createDataSetPermission
       tags:
@@ -2347,6 +2452,7 @@ paths:
     parameters:
       - $ref: '#/parameters/permissionId'
     put:
+      deprecated: true
       summary: Update
       operationId: updateDataSetPermissionsById
       tags:
@@ -2366,6 +2472,7 @@ paths:
           schema:
             $ref: '#/definitions/dataSetPermission'
     delete:
+      deprecated: true
       summary: Delete
       operationId: deleteDataSetPermissionsById
       tags:
@@ -2381,6 +2488,7 @@ paths:
             $ref: '#/definitions/dataSetPermission'
   /api/v1/normalization-types:
     get:
+      deprecated: true
       summary: List types
       operationId: findNormalizationTypes
       tags:
@@ -2396,6 +2504,7 @@ paths:
               $ref: '#/definitions/normalizationType'
   /api/v1/permissions/dataset:
     get:
+      deprecated: true
       summary: List
       operationId: dataSetPermissions
       tags:
@@ -2413,6 +2522,7 @@ paths:
               type: string
   /api/v1/permissions/system:
     get:
+      deprecated: true
       summary: List
       operationId: systemPermissions
       tags:
@@ -2435,7 +2545,7 @@ paths:
       tags:
         - Records
       parameters:
-        - name: datasetId
+        - name: dataSetId
           type: string
           in: query
           required: true
@@ -2473,6 +2583,8 @@ paths:
           description: If record not found.
         '500':
           description: Returns server error if recordId or dataSetId are missing.
+          schema:
+            $ref: '#/definitions/500servererror'
     post:
       summary: Create
       operationId: createRecord
@@ -2522,6 +2634,7 @@ paths:
         required: true
         type: string
     get:
+      deprecated: true
       summary: Get for data set
       operationId: findSinks
       tags:
@@ -2536,6 +2649,7 @@ paths:
             items:
               $ref: '#/definitions/sink'
     post:
+      deprecated: true
       summary: Create
       operationId: createSink
       tags:
@@ -2565,6 +2679,7 @@ paths:
     parameters:
       - $ref: '#/parameters/sinkId'
     get:
+      deprecated: true
       summary: Get
       operationId: findSinkById
       tags:
@@ -2577,6 +2692,7 @@ paths:
           schema:
             $ref: '#/definitions/sink'
     delete:
+      deprecated: true
       summary: Delete
       operationId: deleteSinkById
       tags:
@@ -2591,6 +2707,7 @@ paths:
           schema:
             $ref: '#/definitions/sink'
     put:
+      deprecated: true
       summary: Update
       operationId: updateSinkById
       tags:
@@ -2613,6 +2730,7 @@ paths:
     parameters:
       - $ref: '#/parameters/sinkId'
     get:
+      deprecated: true
       summary: Start
       operationId: exportBySinkId
       tags:
@@ -2628,6 +2746,7 @@ paths:
             $ref: '#/definitions/job'
   /api/v1/sink-schedules:
     get:
+      deprecated: true
       summary: Get
       operationId: findSinkSchedules
       tags:
@@ -2642,6 +2761,7 @@ paths:
             items:
               $ref: '#/definitions/exportSchedule'
     post:
+      deprecated: true
       summary: Create
       operationId: createSinkSchedule
       tags:
@@ -2664,6 +2784,7 @@ paths:
     parameters:
       - $ref: '#/parameters/exportScheduleId'
     get:
+      deprecated: true
       summary: Get
       operationId: findSinkScheduleById
       tags:
@@ -2676,6 +2797,7 @@ paths:
           schema:
             $ref: '#/definitions/exportSchedule'
     delete:
+      deprecated: true
       summary: Delete
       operationId: deleteSinkScheduleById
       tags:
@@ -2689,6 +2811,7 @@ paths:
             $ref: '#/definitions/exportSchedule'
   /api/v1/sink-types:
     get:
+      deprecated: true
       summary: List
       operationId: findSinksTypes
       tags:
@@ -2718,6 +2841,7 @@ paths:
     parameters:
       - $ref: '#/parameters/sinkTypeId'
     get:
+      deprecated: true
       summary: Get
       operationId: findSinkTypeById
       tags:
@@ -2742,6 +2866,7 @@ paths:
           description: Job shutdown
   /api/v1/source-instances:
     post:
+      deprecated: true
       summary: Create
       operationId: addSource
       tags:
@@ -2766,6 +2891,7 @@ paths:
     parameters:
       - $ref: '#/parameters/sourceInstanceId'
     get:
+      deprecated: true
       summary: Get
       operationId: findSourceById
       tags:
@@ -2776,6 +2902,7 @@ paths:
           schema:
             $ref: '#/definitions/source'
     delete:
+      deprecated: true
       summary: Delete
       operationId: deleteSourceById
       tags:
@@ -2786,6 +2913,7 @@ paths:
           schema:
             $ref: '#/definitions/source'
     put:
+      deprecated: true
       summary: Update
       operationId: updateSourceById
       tags:
@@ -2804,6 +2932,7 @@ paths:
             $ref: '#/definitions/sourceInstance'
   /api/v1/source-type-descriptions:
     get:
+      deprecated: true
       summary: List
       operationId: findSourceTypes
       tags:
@@ -2883,7 +3012,7 @@ paths:
           schema:
             $ref: '#/definitions/transform'
       responses:
-        '201':
+        '200':
           description: Returns the newly-added transform
           schema:
             $ref: '#/definitions/transform'
@@ -2986,7 +3115,7 @@ paths:
           schema:
             $ref: '#/definitions/transformSchedule'
       responses:
-        '201':
+        '200':
           description: Returns the newly-added transform schedule
           schema:
             $ref: '#/definitions/transformSchedule'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,7 +52,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Koverse'
-copyright = u'2018, Koverse Inc'
+copyright = u'2019, Koverse Inc'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/open-api/api.yaml
+++ b/open-api/api.yaml
@@ -1,6 +1,6 @@
 swagger: "2.0"
 info:
-  version: 3.0.0
+  version: "3.0"
   title: Koverse REST API
   description: >
         Specification for interacting with the Koverse Rest API
@@ -28,6 +28,8 @@ tags:
           List, inspect, and configure masking for data set attributes
   - name: Data Set Permissions
     description: |
+          Deprecated. Please see Automation Guide for Thrift API usage.
+
           Control access to data in Data Sets.
 
           Access is controlled on a Group basis and includes actions such as writing to a Data Set, querying, deleting, changing configuration, etc.
@@ -35,9 +37,11 @@ tags:
           Note that these permissions are distinct from system permission which control things like which Groups can do things like create Data Sets, setup Transforms etc.
   - name: System Permissions
     description: |
+          Deprecated. Please see Automation Guide for Thrift API usage.
           Control access to system functionality.
   - name: Indexing Policies
     description: |
+          Deprecated. Please see Automation Guide for Thrift API usage.
           Control how Koverse indexes data in a data set.
 
           This includes specifying which attributes to index, how data should be tokenized, and which combinations of attributes should be combined into Composite Indexes.
@@ -53,19 +57,24 @@ tags:
           Write and retrieve individual records and sets of sample records.
   - name: Source Types
     description: |
+          Deprecated. Please see Automation Guide for Thrift API usage.
           List available Source types.
           Source types specify which parameters are available for each type of Source.
   - name: Sources
     description: |
+          Deprecated. Please see Automation Guide for Thrift API usage.
           Sources are external data systems from which Koverse can ingest data.
   - name: Import Flows
     description: |
+          Deprecated. Please see Automation Guide for Thrift API usage.
           Configure a Source to import external data to a specific Data Set.
   - name: Normalizations
     description: |
+          Deprecated. Please see Automation Guide for Thrift API usage.
           Normalizations allow data to be modified as it is imported.
   - name: Import Jobs
     description: |
+          Deprecated. Please see Automation Guide for Thrift API usage.
           Import jobs are used for importing data from an external Source into a Data Set.
 
           These jobs are executed by the Hadoop MapReduce or Spark frameworks asynchronously.
@@ -75,19 +84,23 @@ tags:
           Jobs can be started or shutdown via these methods.
   - name: Import Schedules
     description: |
+          Deprecated. Please see Automation Guide for Thrift API usage.
           Manage schedules for Import Flows.
 
           Schedules control how Import Jobs are started automatically.
           Import Jobs can still be created for Import Flows without schedules on an on-demand basis.
   - name: Transform Types
     description: |
+          Deprecated. Please see Automation Guide for Thrift API usage.
           Get a list of transforms available in the system.
           Transform types specify which parameters are available for each type of Transform.
   - name: Transforms
     description: |
+          Deprecated. Please see Automation Guide for Thrift API usage.
           Setup a partiular Transform Type to transform one or more data sets into a new Data Set.
   - name: Transform Jobs
     description: |
+          Deprecated. Please see Automation Guide for Thrift API usage.
           Transform jobs process new data or all data in input Data Sets and write out results to an output Data Set.
 
           These jobs are executed by the Hadoop MapReduce or Spark frameworks asynchronously.
@@ -97,20 +110,24 @@ tags:
           Jobs can be started or shutdown via these methods.
   - name: Transform Schedules
     description: |
+          Deprecated. Please see Automation Guide for Thrift API usage.
           Manage schedules for Transforms.
 
           Schedules control how Transform Jobs are started automatically.
           Transforms Jobs can still be created for Transforms without schedules on an on-demand basis, or automatically as new data is ingested via Import Jobs into input Data Sets.
   - name: Sink Types
     description: |
+          Deprecated. Please see Automation Guide for Thrift API usage.
           List and get available Sink types.
           Sinks are external systems to which Koverse can export data.
   - name: Sinks
     description: |
+          Deprecated. Please see Automation Guide for Thrift API usage.
           Create, update, and delete Sinks.
           Sinks are external systems to which Koverse can export data.
   - name: Export Jobs
     description: |
+          Deprecated. Please see Automation Guide for Thrift API usage.
           Export jobs write new data or all data in input Data Sets to an external Sink.
 
           These jobs are executed by the Hadoop MapReduce or Spark frameworks asynchronously.
@@ -120,12 +137,14 @@ tags:
           Jobs can be started or shutdown via these methods.
   - name: Sink Schedules
     description: |
+          Deprecated. Please see Automation Guide for Thrift API usage.
           Manage schedules for exporting to Sinks
 
           Schedules control how Export Jobs are started automatically.
           Export Jobs can still be created for Sinks without schedules on an on-demand basis or automatically as new data appears in input Data Sets.
   - name: Jobs
     description: |
+          Deprecated. Please see Automation Guide for Thrift API usage.
           Start, monitor, and cancel data processing jobs.
 
           Data processing jobs are used for importing, transforming, and exporting data.
@@ -140,6 +159,8 @@ tags:
           In some cases a blocked job can be unblocked so it can proceed.
 
 definitions:
+  500servererror:
+    $ref: schemas/servererror.yaml
   apiClient:
     $ref: schemas/apiClient.yaml
   dataSet:
@@ -306,6 +327,8 @@ parameters:
     in: query
     description: length to truncate string values, default is -1 for 'no truncate'
     required: false
+    type: integer
+    format: int64
   normalizationId:
     name: normalizationId
     in: path
@@ -513,7 +536,7 @@ paths:
     $ref: paths/transformTypes.yaml
   /api/v1/transform-types/{typeId}:
     $ref: paths/transformTypeId.yaml
-  /api/v1/queries/:
+  /api/v1/queries/lucene:
     $ref: paths/queryLucene.yaml
   /api/v1/queries/object:
     $ref: paths/queryObject.yaml

--- a/open-api/api.yaml
+++ b/open-api/api.yaml
@@ -202,7 +202,7 @@ definitions:
   parameter:
     $ref: schemas/parameter.yaml
   record:
-    $ref: schemas/record.yaml
+    $ref: schemas/oldjsonrecordformat.yaml
   sink:
     $ref: schemas/sink.yaml
   sinkType:

--- a/open-api/api.yaml
+++ b/open-api/api.yaml
@@ -28,33 +28,29 @@ tags:
           List, inspect, and configure masking for data set attributes
   - name: Data Set Permissions
     description: |
-          Deprecated. Please see Automation Guide for Thrift API usage.
-
           Control access to data in Data Sets.
 
           Access is controlled on a Group basis and includes actions such as writing to a Data Set, querying, deleting, changing configuration, etc.
 
           Note that these permissions are distinct from system permission which control things like which Groups can do things like create Data Sets, setup Transforms etc.
     externalDocs:
-        description: "Automation Guide"
-        url: "automation/intro.rst"
+      description: "Deprecated. Please see Automation Guide for API usage."
+      url: "dev/automation/automationguide.rst"
   - name: System Permissions
     description: |
-          Deprecated. Please see Automation Guide for Thrift API usage.
           Control access to system functionality.
     externalDocs:
-      description: "Automation Guide"
-      url: "automation/intro.rst"
+      description: "Deprecated. Please see Automation Guide for API usage."
+      url: "dev/automation/automationguide.rst"
   - name: Indexing Policies
     description: |
-          Deprecated. Please see Automation Guide for Thrift API usage.
           Control how Koverse indexes data in a data set.
 
           This includes specifying which attributes to index, how data should be tokenized, and which combinations of attributes should be combined into Composite Indexes.
           The set of available indexes affects which kinds of interactive queries Koverse can support.
     externalDocs:
-      description: "Automation Guide"
-      url: "automation/intro.rst"
+      description: "Deprecated. Please see Automation Guide for API usage."
+      url: "dev/automation/automationguide.rst"
   - name: Query
     description: |
           Interactively query Data Sets.
@@ -66,36 +62,31 @@ tags:
           Write and retrieve individual records and sets of sample records.
   - name: Source Types
     description: |
-          Deprecated. Please see Automation Guide for Thrift API usage.
           List available Source types.
           Source types specify which parameters are available for each type of Source.
     externalDocs:
-      description: "Automation Guide"
-      url: "automation/intro.rst"
+      description: "Deprecated. Please see Automation Guide for API usage."
+      url: "dev/automation/automationguide.rst"
   - name: Sources
     description: |
-          Deprecated. Please see Automation Guide for Thrift API usage.
           Sources are external data systems from which Koverse can ingest data.
     externalDocs:
-      description: "Automation Guide"
-      url: "automation/intro.rst"
+      description: "Deprecated. Please see Automation Guide for API usage."
+      url: "dev/automation/automationguide.rst"
   - name: Import Flows
     description: |
-          Deprecated. Please see Automation Guide for Thrift API usage.
           Configure a Source to import external data to a specific Data Set.
     externalDocs:
-      description: "Automation Guide"
-      url: "automation/intro.rst"
+      description: "Deprecated. Please see Automation Guide for API usage."
+      url: "dev/automation/automationguide.rst"
   - name: Normalizations
     description: |
-          Deprecated. Please see Automation Guide for Thrift API usage.
           Normalizations allow data to be modified as it is imported.
     externalDocs:
-      description: "Automation Guide"
-      url: "automation/intro.rst"
+      description: "Deprecated. Please see Automation Guide for API usage."
+      url: "dev/automation/automationguide.rst"
   - name: Import Jobs
     description: |
-          Deprecated. Please see Automation Guide for Thrift API usage.
           Import jobs are used for importing data from an external Source into a Data Set.
 
           These jobs are executed by the Hadoop MapReduce or Spark frameworks asynchronously.
@@ -104,36 +95,32 @@ tags:
 
           Jobs can be started or shutdown via these methods.
     externalDocs:
-      description: "Automation Guide"
-      url: "automation/intro.rst"
+      description: "Deprecated. Please see Automation Guide for API usage."
+      url: "dev/automation/automationguide.rst"
   - name: Import Schedules
     description: |
-          Deprecated. Please see Automation Guide for Thrift API usage.
           Manage schedules for Import Flows.
 
           Schedules control how Import Jobs are started automatically.
           Import Jobs can still be created for Import Flows without schedules on an on-demand basis.
     externalDocs:
-      description: "Automation Guide"
-      url: "automation/intro.rst"
+      description: "Deprecated. Please see Automation Guide for API usage."
+      url: "dev/automation/automationguide.rst"
   - name: Transform Types
     description: |
-          Deprecated. Please see Automation Guide for Thrift API usage.
           Get a list of transforms available in the system.
           Transform types specify which parameters are available for each type of Transform.
     externalDocs:
-      description: "Automation Guide"
-      url: "automation/intro.rst"
+      description: "Deprecated. Please see Automation Guide for API usage."
+      url: "dev/automation/automationguide.rst"
   - name: Transforms
     description: |
-          Deprecated. Please see Automation Guide for Thrift API usage.
           Setup a partiular Transform Type to transform one or more data sets into a new Data Set.
     externalDocs:
-      description: "Automation Guide"
-      url: "automation/intro.rst"
+      description: "Deprecated. Please see Automation Guide for API usage."
+      url: "dev/automation/automationguide.rst"
   - name: Transform Jobs
     description: |
-          Deprecated. Please see Automation Guide for Thrift API usage.
           Transform jobs process new data or all data in input Data Sets and write out results to an output Data Set.
 
           These jobs are executed by the Hadoop MapReduce or Spark frameworks asynchronously.
@@ -142,37 +129,33 @@ tags:
 
           Jobs can be started or shutdown via these methods.
     externalDocs:
-      description: "Automation Guide"
-      url: "automation/intro.rst"
+      description: "Deprecated. Please see Automation Guide for API usage."
+      url: "dev/automation/automationguide.rst"
   - name: Transform Schedules
     description: |
-          Deprecated. Please see Automation Guide for Thrift API usage.
           Manage schedules for Transforms.
 
           Schedules control how Transform Jobs are started automatically.
           Transforms Jobs can still be created for Transforms without schedules on an on-demand basis, or automatically as new data is ingested via Import Jobs into input Data Sets.
     externalDocs:
-      description: "Automation Guide"
-      url: "automation/intro.rst"
+      description: "Deprecated. Please see Automation Guide for API usage."
+      url: "dev/automation/automationguide.rst"
   - name: Sink Types
     description: |
-          Deprecated. Please see Automation Guide for Thrift API usage.
           List and get available Sink types.
           Sinks are external systems to which Koverse can export data.
     externalDocs:
-      description: "Automation Guide"
-      url: "automation/intro.rst"
+      description: "Deprecated. Please see Automation Guide for API usage."
+      url: "dev/automation/automationguide.rst"
   - name: Sinks
     description: |
-          Deprecated. Please see Automation Guide for Thrift API usage.
           Create, update, and delete Sinks.
           Sinks are external systems to which Koverse can export data.
     externalDocs:
-      description: "Automation Guide"
-      url: "automation/intro.rst"
+      description: "Deprecated. Please see Automation Guide for API usage."
+      url: "dev/automation/automationguide.rst"
   - name: Export Jobs
     description: |
-          Deprecated. Please see Automation Guide for Thrift API usage.
           Export jobs write new data or all data in input Data Sets to an external Sink.
 
           These jobs are executed by the Hadoop MapReduce or Spark frameworks asynchronously.
@@ -181,21 +164,19 @@ tags:
 
           Jobs can be started or shutdown via these methods.
     externalDocs:
-      description: "Automation Guide"
-      url: "automation/intro.rst"
+      description: "Deprecated. Please see Automation Guide for API usage."
+      url: "dev/automation/automationguide.rst"
   - name: Sink Schedules
     description: |
-          Deprecated. Please see Automation Guide for Thrift API usage.
           Manage schedules for exporting to Sinks
 
           Schedules control how Export Jobs are started automatically.
           Export Jobs can still be created for Sinks without schedules on an on-demand basis or automatically as new data appears in input Data Sets.
     externalDocs:
-      description: "Automation Guide"
-      url: "automation/intro.rst"
+      description: "Deprecated. Please see Automation Guide for API usage."
+      url: "dev/automation/automationguide.rst"
   - name: Jobs
     description: |
-          Deprecated. Please see Automation Guide for Thrift API usage.
           Start, monitor, and cancel data processing jobs.
 
           Data processing jobs are used for importing, transforming, and exporting data.
@@ -209,8 +190,8 @@ tags:
           If two or more jobs will write on the same data set, one job may become blocked to allow the other job to complete its processing without inteference.
           In some cases a blocked job can be unblocked so it can proceed.
     externalDocs:
-      description: "Automation Guide"
-      url: "automation/intro.rst"
+      description: "Deprecated. Please see Automation Guide for API usage."
+      url: "dev/automation/automationguide.rst"
 
 definitions:
   500servererror:

--- a/open-api/api.yaml
+++ b/open-api/api.yaml
@@ -35,10 +35,16 @@ tags:
           Access is controlled on a Group basis and includes actions such as writing to a Data Set, querying, deleting, changing configuration, etc.
 
           Note that these permissions are distinct from system permission which control things like which Groups can do things like create Data Sets, setup Transforms etc.
+    externalDocs:
+        description: "Automation Guide"
+        url: "automation/intro.rst"
   - name: System Permissions
     description: |
           Deprecated. Please see Automation Guide for Thrift API usage.
           Control access to system functionality.
+    externalDocs:
+      description: "Automation Guide"
+      url: "automation/intro.rst"
   - name: Indexing Policies
     description: |
           Deprecated. Please see Automation Guide for Thrift API usage.
@@ -46,6 +52,9 @@ tags:
 
           This includes specifying which attributes to index, how data should be tokenized, and which combinations of attributes should be combined into Composite Indexes.
           The set of available indexes affects which kinds of interactive queries Koverse can support.
+    externalDocs:
+      description: "Automation Guide"
+      url: "automation/intro.rst"
   - name: Query
     description: |
           Interactively query Data Sets.
@@ -60,18 +69,30 @@ tags:
           Deprecated. Please see Automation Guide for Thrift API usage.
           List available Source types.
           Source types specify which parameters are available for each type of Source.
+    externalDocs:
+      description: "Automation Guide"
+      url: "automation/intro.rst"
   - name: Sources
     description: |
           Deprecated. Please see Automation Guide for Thrift API usage.
           Sources are external data systems from which Koverse can ingest data.
+    externalDocs:
+      description: "Automation Guide"
+      url: "automation/intro.rst"
   - name: Import Flows
     description: |
           Deprecated. Please see Automation Guide for Thrift API usage.
           Configure a Source to import external data to a specific Data Set.
+    externalDocs:
+      description: "Automation Guide"
+      url: "automation/intro.rst"
   - name: Normalizations
     description: |
           Deprecated. Please see Automation Guide for Thrift API usage.
           Normalizations allow data to be modified as it is imported.
+    externalDocs:
+      description: "Automation Guide"
+      url: "automation/intro.rst"
   - name: Import Jobs
     description: |
           Deprecated. Please see Automation Guide for Thrift API usage.
@@ -82,6 +103,9 @@ tags:
           Jobs may run simultaneously as cluster resources allow.
 
           Jobs can be started or shutdown via these methods.
+    externalDocs:
+      description: "Automation Guide"
+      url: "automation/intro.rst"
   - name: Import Schedules
     description: |
           Deprecated. Please see Automation Guide for Thrift API usage.
@@ -89,15 +113,24 @@ tags:
 
           Schedules control how Import Jobs are started automatically.
           Import Jobs can still be created for Import Flows without schedules on an on-demand basis.
+    externalDocs:
+      description: "Automation Guide"
+      url: "automation/intro.rst"
   - name: Transform Types
     description: |
           Deprecated. Please see Automation Guide for Thrift API usage.
           Get a list of transforms available in the system.
           Transform types specify which parameters are available for each type of Transform.
+    externalDocs:
+      description: "Automation Guide"
+      url: "automation/intro.rst"
   - name: Transforms
     description: |
           Deprecated. Please see Automation Guide for Thrift API usage.
           Setup a partiular Transform Type to transform one or more data sets into a new Data Set.
+    externalDocs:
+      description: "Automation Guide"
+      url: "automation/intro.rst"
   - name: Transform Jobs
     description: |
           Deprecated. Please see Automation Guide for Thrift API usage.
@@ -108,6 +141,9 @@ tags:
           Jobs may run simultaneously as cluster resources allow.
 
           Jobs can be started or shutdown via these methods.
+    externalDocs:
+      description: "Automation Guide"
+      url: "automation/intro.rst"
   - name: Transform Schedules
     description: |
           Deprecated. Please see Automation Guide for Thrift API usage.
@@ -115,16 +151,25 @@ tags:
 
           Schedules control how Transform Jobs are started automatically.
           Transforms Jobs can still be created for Transforms without schedules on an on-demand basis, or automatically as new data is ingested via Import Jobs into input Data Sets.
+    externalDocs:
+      description: "Automation Guide"
+      url: "automation/intro.rst"
   - name: Sink Types
     description: |
           Deprecated. Please see Automation Guide for Thrift API usage.
           List and get available Sink types.
           Sinks are external systems to which Koverse can export data.
+    externalDocs:
+      description: "Automation Guide"
+      url: "automation/intro.rst"
   - name: Sinks
     description: |
           Deprecated. Please see Automation Guide for Thrift API usage.
           Create, update, and delete Sinks.
           Sinks are external systems to which Koverse can export data.
+    externalDocs:
+      description: "Automation Guide"
+      url: "automation/intro.rst"
   - name: Export Jobs
     description: |
           Deprecated. Please see Automation Guide for Thrift API usage.
@@ -135,6 +180,9 @@ tags:
           Jobs may run simultaneously as cluster resources allow.
 
           Jobs can be started or shutdown via these methods.
+    externalDocs:
+      description: "Automation Guide"
+      url: "automation/intro.rst"
   - name: Sink Schedules
     description: |
           Deprecated. Please see Automation Guide for Thrift API usage.
@@ -142,6 +190,9 @@ tags:
 
           Schedules control how Export Jobs are started automatically.
           Export Jobs can still be created for Sinks without schedules on an on-demand basis or automatically as new data appears in input Data Sets.
+    externalDocs:
+      description: "Automation Guide"
+      url: "automation/intro.rst"
   - name: Jobs
     description: |
           Deprecated. Please see Automation Guide for Thrift API usage.
@@ -157,6 +208,9 @@ tags:
 
           If two or more jobs will write on the same data set, one job may become blocked to allow the other job to complete its processing without inteference.
           In some cases a blocked job can be unblocked so it can proceed.
+    externalDocs:
+      description: "Automation Guide"
+      url: "automation/intro.rst"
 
 definitions:
   500servererror:

--- a/open-api/api.yaml
+++ b/open-api/api.yaml
@@ -35,13 +35,13 @@ tags:
           Note that these permissions are distinct from system permission which control things like which Groups can do things like create Data Sets, setup Transforms etc.
     externalDocs:
       description: "Deprecated. Please see Automation Guide for API usage."
-      url: "dev/automation/automationguide.rst"
+      url: "dev/automation/automationguide.html"
   - name: System Permissions
     description: |
           Control access to system functionality.
     externalDocs:
       description: "Deprecated. Please see Automation Guide for API usage."
-      url: "dev/automation/automationguide.rst"
+      url: "dev/automation/automationguide.html"
   - name: Indexing Policies
     description: |
           Control how Koverse indexes data in a data set.
@@ -50,7 +50,7 @@ tags:
           The set of available indexes affects which kinds of interactive queries Koverse can support.
     externalDocs:
       description: "Deprecated. Please see Automation Guide for API usage."
-      url: "dev/automation/automationguide.rst"
+      url: "dev/automation/automationguide.html"
   - name: Query
     description: |
           Interactively query Data Sets.
@@ -66,25 +66,25 @@ tags:
           Source types specify which parameters are available for each type of Source.
     externalDocs:
       description: "Deprecated. Please see Automation Guide for API usage."
-      url: "dev/automation/automationguide.rst"
+      url: "dev/automation/automationguide.html"
   - name: Sources
     description: |
           Sources are external data systems from which Koverse can ingest data.
     externalDocs:
       description: "Deprecated. Please see Automation Guide for API usage."
-      url: "dev/automation/automationguide.rst"
+      url: "dev/automation/automationguide.html"
   - name: Import Flows
     description: |
           Configure a Source to import external data to a specific Data Set.
     externalDocs:
       description: "Deprecated. Please see Automation Guide for API usage."
-      url: "dev/automation/automationguide.rst"
+      url: "dev/automation/automationguide.html"
   - name: Normalizations
     description: |
           Normalizations allow data to be modified as it is imported.
     externalDocs:
       description: "Deprecated. Please see Automation Guide for API usage."
-      url: "dev/automation/automationguide.rst"
+      url: "dev/automation/automationguide.html"
   - name: Import Jobs
     description: |
           Import jobs are used for importing data from an external Source into a Data Set.
@@ -96,7 +96,7 @@ tags:
           Jobs can be started or shutdown via these methods.
     externalDocs:
       description: "Deprecated. Please see Automation Guide for API usage."
-      url: "dev/automation/automationguide.rst"
+      url: "dev/automation/automationguide.html"
   - name: Import Schedules
     description: |
           Manage schedules for Import Flows.
@@ -105,20 +105,20 @@ tags:
           Import Jobs can still be created for Import Flows without schedules on an on-demand basis.
     externalDocs:
       description: "Deprecated. Please see Automation Guide for API usage."
-      url: "dev/automation/automationguide.rst"
+      url: "dev/automation/automationguide.html"
   - name: Transform Types
     description: |
           Get a list of transforms available in the system.
           Transform types specify which parameters are available for each type of Transform.
     externalDocs:
       description: "Deprecated. Please see Automation Guide for API usage."
-      url: "dev/automation/automationguide.rst"
+      url: "dev/automation/automationguide.html"
   - name: Transforms
     description: |
           Setup a partiular Transform Type to transform one or more data sets into a new Data Set.
     externalDocs:
       description: "Deprecated. Please see Automation Guide for API usage."
-      url: "dev/automation/automationguide.rst"
+      url: "dev/automation/automationguide.html"
   - name: Transform Jobs
     description: |
           Transform jobs process new data or all data in input Data Sets and write out results to an output Data Set.
@@ -130,7 +130,7 @@ tags:
           Jobs can be started or shutdown via these methods.
     externalDocs:
       description: "Deprecated. Please see Automation Guide for API usage."
-      url: "dev/automation/automationguide.rst"
+      url: "dev/automation/automationguide.html"
   - name: Transform Schedules
     description: |
           Manage schedules for Transforms.
@@ -139,21 +139,21 @@ tags:
           Transforms Jobs can still be created for Transforms without schedules on an on-demand basis, or automatically as new data is ingested via Import Jobs into input Data Sets.
     externalDocs:
       description: "Deprecated. Please see Automation Guide for API usage."
-      url: "dev/automation/automationguide.rst"
+      url: "dev/automation/automationguide.html"
   - name: Sink Types
     description: |
           List and get available Sink types.
           Sinks are external systems to which Koverse can export data.
     externalDocs:
       description: "Deprecated. Please see Automation Guide for API usage."
-      url: "dev/automation/automationguide.rst"
+      url: "dev/automation/automationguide.html"
   - name: Sinks
     description: |
           Create, update, and delete Sinks.
           Sinks are external systems to which Koverse can export data.
     externalDocs:
       description: "Deprecated. Please see Automation Guide for API usage."
-      url: "dev/automation/automationguide.rst"
+      url: "dev/automation/automationguide.html"
   - name: Export Jobs
     description: |
           Export jobs write new data or all data in input Data Sets to an external Sink.
@@ -165,7 +165,7 @@ tags:
           Jobs can be started or shutdown via these methods.
     externalDocs:
       description: "Deprecated. Please see Automation Guide for API usage."
-      url: "dev/automation/automationguide.rst"
+      url: "dev/automation/automationguide.html"
   - name: Sink Schedules
     description: |
           Manage schedules for exporting to Sinks
@@ -174,7 +174,7 @@ tags:
           Export Jobs can still be created for Sinks without schedules on an on-demand basis or automatically as new data appears in input Data Sets.
     externalDocs:
       description: "Deprecated. Please see Automation Guide for API usage."
-      url: "dev/automation/automationguide.rst"
+      url: "dev/automation/automationguide.html"
   - name: Jobs
     description: |
           Start, monitor, and cancel data processing jobs.
@@ -191,7 +191,7 @@ tags:
           In some cases a blocked job can be unblocked so it can proceed.
     externalDocs:
       description: "Deprecated. Please see Automation Guide for API usage."
-      url: "dev/automation/automationguide.rst"
+      url: "dev/automation/automationguide.html"
 
 definitions:
   500servererror:

--- a/open-api/paths/applicationId.yaml
+++ b/open-api/paths/applicationId.yaml
@@ -2,6 +2,7 @@ parameters:
   - $ref: "../api.yaml#/parameters/applicationId"
 
 get:
+  deprecated: true
   summary: Get
   description: |
         Get the details about the given application.
@@ -14,6 +15,7 @@ get:
         $ref: "../api.yaml#/definitions/apiClient"
 
 put:
+  deprecated: true
   summary: Update
   description: |
         Update the application details.
@@ -26,6 +28,7 @@ put:
         $ref: "../api.yaml#/definitions/apiClient"
 
 delete:
+  deprecated: true
   summary: Delete
   description: |
           Delete the application specified by id.

--- a/open-api/paths/applications.yaml
+++ b/open-api/paths/applications.yaml
@@ -1,4 +1,5 @@
 get:
+  deprecated: true
   summary: List
   operationId: findApplications
   tags: ["Applications"]
@@ -14,6 +15,7 @@ get:
           $ref: "../api.yaml#/definitions/apiClient"
 
 post:
+  deprecated: true
   summary: Create
   operationId: createApplication
   tags: ["Applications"]
@@ -27,7 +29,7 @@ post:
       schema:
         $ref: '../api.yaml#/definitions/apiClient'
   responses:
-    201:
+    200:
       description: Returns the newly created Application
       schema:
         $ref: "../api.yaml#/definitions/apiClient"

--- a/open-api/paths/dataSetAttributeNames.yaml
+++ b/open-api/paths/dataSetAttributeNames.yaml
@@ -32,5 +32,6 @@ get:
       #   - plot_keywords
       #   - title_year
     500:
-      description: Data set not found 
-      message: "If data set not found message will read 'Internal error processing getDataSetAttributeNames'"
+      description: If data set not found message will read 'Internal error processing getDataSetAttributeNames'
+      schema:
+        $ref: "../api.yaml#/definitions/500servererror"

--- a/open-api/paths/dataSetAttributes.yaml
+++ b/open-api/paths/dataSetAttributes.yaml
@@ -16,5 +16,6 @@ get:
         items:
           $ref: "../api.yaml#/definitions/dataSetAttributes"
     500:
-      description: Data set not found 
-      message: If data set not found message will read 'Could not find database object in method...'
+      description: If data set not found message will read 'Could not find database object in method...'
+      schema:
+        $ref: "../api.yaml#/definitions/500servererror"

--- a/open-api/paths/dataSetClearDataSet.yaml
+++ b/open-api/paths/dataSetClearDataSet.yaml
@@ -13,5 +13,6 @@ get:
     200:
       description: '200 OK'
     500:
-      description: Data set not found 
-      message: If data set not found message will read 'No content to map to Object due to end of input'
+      description: If data set not found message will read 'No content to map to Object due to end of input'
+      schema:
+        $ref: "../api.yaml#/definitions/500servererror"

--- a/open-api/paths/dataSetId.yaml
+++ b/open-api/paths/dataSetId.yaml
@@ -17,6 +17,8 @@ get:
         $ref: "../api.yaml#/definitions/dataSetMetadata"
     500:
       description: Returns server error if no data set is found
+      schema :
+        $ref: "../api.yaml#/definitions/500servererror"
 
 put:
   summary: Update
@@ -42,5 +44,6 @@ delete:
       schema:
         $ref: "../api.yaml#/definitions/dataSetMetadata"
     500:
-      description: Data set not found 
-      message: If data set not found message will read 'No content to map to Object due to end of input'
+      description: If data set not found message will read 'No content to map to Object due to end of input'
+      schema:
+        $ref: "../api.yaml#/definitions/500servererror"

--- a/open-api/paths/dataSetPermissionId.yaml
+++ b/open-api/paths/dataSetPermissionId.yaml
@@ -2,6 +2,7 @@ parameters:
   - $ref: "../api.yaml#/parameters/permissionId"
 
 put:
+  deprecated: true
   summary: Update
   operationId: updateDataSetPermissionsById
   tags: ["Data Set Permissions"]
@@ -21,6 +22,7 @@ put:
         $ref: "../api.yaml#/definitions/dataSetPermission"
 
 delete:
+  deprecated: true
   summary: Delete
   operationId: deleteDataSetPermissionsById
   tags: ["Data Set Permissions"]

--- a/open-api/paths/dataSetRepair.yaml
+++ b/open-api/paths/dataSetRepair.yaml
@@ -13,5 +13,6 @@ get:
     200:
       description: '200 OK'
     500:
-      description: Data set not found 
-      message: If data set not found message will read 'No content to map to Object due to end of input'
+      description: If data set not found message will read 'No content to map to Object due to end of input'
+      schema:
+        $ref: "../api.yaml#/definitions/500servererror"

--- a/open-api/paths/dataSets.yaml
+++ b/open-api/paths/dataSets.yaml
@@ -14,7 +14,6 @@ get:
         type: array
         items:
           $ref: "../api.yaml#/definitions/dataSetMetadata"
-
 post:
   summary: Create
   operationId: createDataSet

--- a/open-api/paths/exportJobsShutdown.yaml
+++ b/open-api/paths/exportJobsShutdown.yaml
@@ -9,4 +9,4 @@ get:
         Shuts down a running export job.
   responses:
     200:
-      description: 200 OK
+      description: Job shutdown

--- a/open-api/paths/importFlowExecute.yaml
+++ b/open-api/paths/importFlowExecute.yaml
@@ -2,6 +2,7 @@ parameters:
   - $ref: "../api.yaml#/parameters/importFlowIdPath"
 
 post:
+  deprecated: true
   summary: Start
   operationId: funImportFlowById
   tags: ["Import Jobs"]

--- a/open-api/paths/importFlowId.yaml
+++ b/open-api/paths/importFlowId.yaml
@@ -2,6 +2,7 @@ parameters:
   - $ref: "../api.yaml#/parameters/importFlowIdPath"
 
 get:
+  deprecated: true
   summary: Get
   operationId: findImportFlowById
   tags: ["Import Flows"]
@@ -17,6 +18,7 @@ get:
       #     description: The date/time that the import flow was last modified
 
 delete:
+  deprecated: true
   summary: Delete
   operationId: deleteImportFlowById
   tags: ["Import Flows"]
@@ -28,6 +30,7 @@ delete:
         $ref: "../api.yaml#/definitions/importFlow"
 
 put:
+  deprecated: true
   summary: Update
   operationId: updateImportFlowById
   tags: ["Import Flows"]

--- a/open-api/paths/importFlowNormalizations.yaml
+++ b/open-api/paths/importFlowNormalizations.yaml
@@ -1,6 +1,7 @@
 parameters:
   - $ref: "../api.yaml#/parameters/importFlowIdPath"
 get:
+  deprecated: true
   summary: Get for an import flow
   tags: ["Normalizations"]
   operationId: findNormalizations
@@ -15,6 +16,7 @@ get:
           $ref: "../api.yaml#/definitions/normalization"
 
 post:
+  deprecated: true
   summary: Create
   tags: ["Normalizations"]
   operationId: addNormalization

--- a/open-api/paths/importFlowNormalizationsId.yaml
+++ b/open-api/paths/importFlowNormalizationsId.yaml
@@ -3,6 +3,7 @@ parameters:
   - $ref: "../api.yaml#/parameters/normalizationId"
 
 get:
+  deprecated: true
   summary: Get
   operationId: findNormalizationById
   tags: ["Normalizations"]
@@ -14,6 +15,7 @@ get:
         $ref: "../api.yaml#/definitions/normalization"
 
 put:
+  deprecated: true
   summary: Update
   operationId: updateNormalizationById
   tags: ["Normalizations"]
@@ -32,6 +34,7 @@ put:
         $ref: "../api.yaml#/definitions/normalization"
 
 delete:
+  deprecated: true
   summary: Delete
   operationId: deleteNormalization
   tags: ["Normalizations"]

--- a/open-api/paths/importFlowSchedules.yaml
+++ b/open-api/paths/importFlowSchedules.yaml
@@ -2,6 +2,7 @@ parameters:
   - $ref: "../api.yaml#/parameters/importFlowIdPath"
 
 get:
+  deprecated: true
   summary: Get by Import Flow
   operationId: findImportSchedules
   tags: ["Import Schedules"]

--- a/open-api/paths/importFlowSourceId.yaml
+++ b/open-api/paths/importFlowSourceId.yaml
@@ -2,6 +2,7 @@ parameters:
   - $ref: "../api.yaml#/parameters/sourceId"
 
 get:
+  deprecated: true
   summary: Get by source
   operationId: findImportFlowBySourceId
   tags: ["Import Flows"]

--- a/open-api/paths/importFlows.yaml
+++ b/open-api/paths/importFlows.yaml
@@ -1,4 +1,5 @@
 post:
+  deprecated: true
   summary: Create
   operationId: addImportFlow
   tags: ["Import Flows"]

--- a/open-api/paths/importJobsShutdown.yaml
+++ b/open-api/paths/importJobsShutdown.yaml
@@ -2,6 +2,7 @@ parameters:
   - $ref: "../api.yaml#/parameters/importJobId"
 
 get:
+  deprecated: true
   summary: Shutdown
   operationId: shutdownImportJobById
   tags: ["Import Jobs"]

--- a/open-api/paths/importScheduleId.yaml
+++ b/open-api/paths/importScheduleId.yaml
@@ -2,6 +2,7 @@ parameters:
   - $ref: "../api.yaml#/parameters/importScheduleId"
 
 get:
+  deprecated: true
   summary: Get
   operationId: findImportScheduleById
   tags: ["Import Schedules"]
@@ -18,6 +19,7 @@ get:
       #     description: The date/time that the import schedule was last modified
 
 delete:
+  deprecated: true
   summary: Delete
   operationId: deleteImportSchedule
   tags: ["Import Schedules"]

--- a/open-api/paths/importSchedules.yaml
+++ b/open-api/paths/importSchedules.yaml
@@ -22,6 +22,7 @@ parameters:
       #     description: The date/time that a schedule was last modified
 
 post:
+  deprecated: true
   summary: Create
   operationId: addImportSchedule
   tags: ["Import Schedules"]

--- a/open-api/paths/jobs.yaml
+++ b/open-api/paths/jobs.yaml
@@ -1,4 +1,5 @@
 get:
+  deprecated: true
   summary: Get active
   operationId: findActiveJobs
   tags: ["Jobs"]

--- a/open-api/paths/jobsIdShutdown.yaml
+++ b/open-api/paths/jobsIdShutdown.yaml
@@ -9,4 +9,4 @@ get:
           Shutdown the specified job.
   responses:
     200:
-      description: '200 OK'
+      description: Shutdown successful

--- a/open-api/paths/jobsIdUnblock.yaml
+++ b/open-api/paths/jobsIdUnblock.yaml
@@ -11,4 +11,4 @@ get:
           This will cause the job to be started as soon as cluster resources allow.
   responses:
     200:
-      description: '200 OK'
+      description: Job unblocked

--- a/open-api/paths/normalizationTypes.yaml
+++ b/open-api/paths/normalizationTypes.yaml
@@ -1,4 +1,5 @@
 get:
+  deprecated: true
   summary: List types
   operationId: findNormalizationTypes
   tags: ["Normalizations"]

--- a/open-api/paths/permissions.yaml
+++ b/open-api/paths/permissions.yaml
@@ -1,4 +1,5 @@
 post:
+  deprecated: true
   summary: Create
   operationId: createDataSetPermission
   tags: ["Permissions"]

--- a/open-api/paths/permissionsDataSet.yaml
+++ b/open-api/paths/permissionsDataSet.yaml
@@ -1,4 +1,5 @@
 get:
+  deprecated: true
   summary: List
   operationId: dataSetPermissions
   tags: ["Data Set Permissions"]

--- a/open-api/paths/permissionsSystem.yaml
+++ b/open-api/paths/permissionsSystem.yaml
@@ -1,4 +1,5 @@
 get:
+  deprecated: true
   summary: List
   operationId: systemPermissions
   tags: ["System Permissions"]

--- a/open-api/paths/records.yaml
+++ b/open-api/paths/records.yaml
@@ -37,10 +37,10 @@ get:
       #   flatSchema: true
       #   records:
       #     - $ref: "../schemas/recordExample.yaml"
-    404:
-      description: If record not found.
     500:
       description: Returns server error if recordId or dataSetId are missing.
+      schema:
+        $ref: "../api.yaml#/definitions/500servererror"
 
 post:
   summary: Create

--- a/open-api/paths/records.yaml
+++ b/open-api/paths/records.yaml
@@ -3,7 +3,7 @@ parameters:
   - $ref: "../api.yaml#/parameters/recordId"
 get:
   summary: Get
-  operationId: getRecordById
+  operationId: getRecord
   tags: ["Records"]
   parameters:
     - name: dataSetId
@@ -15,7 +15,7 @@ get:
       in: query
       required: true
   description: |
-        Get a single record by data set id and record id.
+        Get a single record by data set id and record id. (Note: recordIds may have a delimiter that is not valid json)
 
         Note that the Record ID must be known in order to use this method.
         It is intended to be used by applications that need to fetch one record, often one that is related to some other record.

--- a/open-api/paths/sinkId.yaml
+++ b/open-api/paths/sinkId.yaml
@@ -2,6 +2,7 @@ parameters:
   - $ref: "../api.yaml#/parameters/sinkId"
 
 get:
+  deprecated: true
   summary: Get
   operationId: findSinkById
   tags: ["Sinks"]
@@ -18,6 +19,7 @@ get:
       #     description: The date/time that the sink was last modified
 
 delete:
+  deprecated: true
   summary: Delete
   operationId: deleteSinkById
   tags: ["Sinks"]
@@ -32,6 +34,7 @@ delete:
         $ref: "../api.yaml#/definitions/sink"
 
 put:
+  deprecated: true
   summary: Update
   operationId: updateSinkById
   tags: ["Sinks"]

--- a/open-api/paths/sinkRunExport.yaml
+++ b/open-api/paths/sinkRunExport.yaml
@@ -2,6 +2,7 @@ parameters:
   - $ref: "../api.yaml#/parameters/sinkId"
 
 get:
+  deprecated: true
   summary: Start
   operationId: exportBySinkId
   tags: ["Export Jobs"]

--- a/open-api/paths/sinkScheduleId.yaml
+++ b/open-api/paths/sinkScheduleId.yaml
@@ -2,6 +2,7 @@ parameters:
   - $ref: "../api.yaml#/parameters/exportScheduleId"
 
 get:
+  deprecated: true
   summary: Get
   operationId: findSinkScheduleById
   tags: ["Sink Schedules"]
@@ -18,6 +19,7 @@ get:
       #     description: The date/time that the sink schedule was last modified
 
 delete:
+  deprecated: true
   summary: Delete
   operationId: deleteSinkScheduleById
   tags: ["Sink Schedules"]

--- a/open-api/paths/sinkSchedules.yaml
+++ b/open-api/paths/sinkSchedules.yaml
@@ -1,4 +1,5 @@
 get:
+  deprecated: true
   summary: Get
   operationId: findSinkSchedules
   tags: ["Sink Schedules"]
@@ -17,6 +18,7 @@ get:
       #     description: The date/time that a schedule was last modified
 
 post:
+  deprecated: true
   summary: Create
   operationId: createSinkSchedule
   tags: ["Sink Schedules"]

--- a/open-api/paths/sinkTypeId.yaml
+++ b/open-api/paths/sinkTypeId.yaml
@@ -2,6 +2,7 @@ parameters:
   - $ref: "../api.yaml#/parameters/sinkTypeId"
 
 get:
+  deprecated: true
   summary: Get
   operationId: findSinkTypeById
   tags: ["Sink Types"]

--- a/open-api/paths/sinkTypes.yaml
+++ b/open-api/paths/sinkTypes.yaml
@@ -1,4 +1,5 @@
 get:
+  deprecated: true
   summary: List
   operationId: findSinksTypes
   tags: ["Sink Types"]

--- a/open-api/paths/sinks.yaml
+++ b/open-api/paths/sinks.yaml
@@ -6,6 +6,7 @@ parameters:
     type: string
 
 get:
+  deprecated: true
   summary: Get for data set
   operationId: findSinks
   tags: ["Sinks"]
@@ -20,6 +21,7 @@ get:
           $ref: "../api.yaml#/definitions/sink"
 
 post:
+  deprecated: true
   summary: Create
   operationId: createSink
   tags: ["Sinks"]

--- a/open-api/paths/sourceInstanceId.yaml
+++ b/open-api/paths/sourceInstanceId.yaml
@@ -2,6 +2,7 @@ parameters:
   - $ref: "../api.yaml#/parameters/sourceInstanceId"
 
 get:
+  deprecated: true
   summary: Get
   operationId: findSourceById
   tags: ["Sources"]
@@ -16,6 +17,7 @@ get:
       #     description: The date/time that the source was last modified
 
 delete:
+  deprecated: true
   summary: Delete
   operationId: deleteSourceById
   tags: ["Sources"]
@@ -26,6 +28,7 @@ delete:
         $ref: "../api.yaml#/definitions/source"
 
 put:
+  deprecated: true
   summary: Update
   operationId: updateSourceById
   tags: ["Sources"]

--- a/open-api/paths/sourceInstances.yaml
+++ b/open-api/paths/sourceInstances.yaml
@@ -1,4 +1,5 @@
 post:
+  deprecated: true
   summary: Create
   operationId: addSource
   tags: ["Sources"]

--- a/open-api/paths/sourceTypeDescriptions.yaml
+++ b/open-api/paths/sourceTypeDescriptions.yaml
@@ -1,4 +1,5 @@
 get:
+  deprecated: true
   summary: List
   operationId: findSourceTypes
   tags: ["Source Types"]

--- a/open-api/paths/transformIdSchedules.yaml
+++ b/open-api/paths/transformIdSchedules.yaml
@@ -33,7 +33,7 @@ post:
       schema:
         $ref: "../api.yaml#/definitions/transformSchedule"
   responses:
-    201:
+    200:
       description: Returns the newly-added transform schedule
       schema:
         $ref: "../api.yaml#/definitions/transformSchedule"

--- a/open-api/paths/transforms.yaml
+++ b/open-api/paths/transforms.yaml
@@ -37,7 +37,7 @@ post:
       schema:
         $ref: "../api.yaml#/definitions/transform"
   responses:
-    201:
+    200:
       description: Returns the newly-added transform
       schema:
         $ref: "../api.yaml#/definitions/transform"

--- a/open-api/schemas/dataSetMetadata.yaml
+++ b/open-api/schemas/dataSetMetadata.yaml
@@ -15,8 +15,6 @@ properties:
     description: A user-readable description of the data set.
   deleted:
     type: boolean
-  groupPermissionsIds:
-    type: array
   indexingPolicyId:
     type: integer
   indexingPolicy:

--- a/open-api/schemas/objectQueryNames.yaml
+++ b/open-api/schemas/objectQueryNames.yaml
@@ -2,7 +2,7 @@ type: object
 required:
   - query
 description: >
-      This object contains the parameters used to issue a query against one or more data sets. The query is defined as a JSON string
+      This object contains the parameters used to issue a query against one or more data sets. The query is defined as a JSON string. The query will return an empty array '[]' if no records are found.
 properties:
   collectionNames:
     type: array

--- a/open-api/schemas/oldjsonformatexample.yaml
+++ b/open-api/schemas/oldjsonformatexample.yaml
@@ -1,0 +1,7 @@
+recordId: 1
+collectionId: wiki_20191101_135232_062
+securityLabel: ""
+fields:
+  id: 576
+  name: bob
+  age: 35

--- a/open-api/schemas/oldjsonrecordformat.yaml
+++ b/open-api/schemas/oldjsonrecordformat.yaml
@@ -1,0 +1,15 @@
+type: object
+properties:
+  recordId:
+    type: string
+  collectionId:
+    type: string
+  securityLabel:
+    type: string
+  fields:
+    type: object
+    description: >
+      An object containing the fields and values within this record.
+      The structure of this object will vary from data set to data set.
+example:
+  $ref: "oldjsonformatexample.yaml"

--- a/open-api/schemas/servererror.yaml
+++ b/open-api/schemas/servererror.yaml
@@ -1,0 +1,5 @@
+type: string
+description: >
+  An error has occurred.
+example:
+  500 Server Error, No data sets found.


### PR DESCRIPTION
This covers changes specified in:

https://koverse.atlassian.net/browse/KC-5968
https://koverse.atlassian.net/browse/KC-5917
https://koverse.atlassian.net/browse/KC-5966
and fixing build problems with 
https://koverse.atlassian.net/browse/KC-5916

All non-web rest endpoints have been marked as deprecated.
The non-web rest endpoints are in the following sections:
DataSet Permissions
System Permissions
Source Types
Sources
Import Flows
Normalizations
Import Jobs
Import Schedules
Sink Types
Export Jobs
Sink Schedules
Jobs
Applications
Permissions

The openapi files were updated in KC-5916 but not built using npm so the changes didn't show up. That has been fixed, as well as, any other changes that were only made in source/api.yaml (which is the file that is built).

KC-5968 addressed some of the "missing" changes plus a few others. Including:
   1. Documentation shows GET /api/v1/queries/ for lucene query but it is actually GET /api/v1/queries/lucene
   2. Documentation says GET /api/v1/records returns a 404 when recordId is not found but it actually returns a 500
  3. Documentation shows wrong response body for GET /api/v1/records. It is actually an OldJsonRecord, but docs show same response as GET /api/v1/data-sets/{dataSetId}/records

Added additional information to explain that v1/queries/object/names returns an empty array when there are no records to return (KC-5966)