### PR TITLE
Kc 5990 merge 2.11 into 3.0

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -8,6 +8,7 @@ Release Notes
    :maxdepth: 1
 
    releasenotes/3.0.rst
+   releasenotes/2.11.rst
    releasenotes/2.10.rst
    releasenotes/2.9.rst
    releasenotes/2.8.rst

--- a/docs/source/releasenotes/2.11.rst
+++ b/docs/source/releasenotes/2.11.rst
@@ -1,0 +1,32 @@
+.. _Version211ReleaseNotes:
+
+2.11 Release Notes
+==================
+
+Koverse version 2.11 introduces the ability to extend the Koverse UI to allow users to login with a custom web authenticator.
+
+See the new :ref:`Authentication` for background.
+
+Features
+------------
+
+- [KC-5903] - Support login via UI with custom web authenticator
+
+
+Bug Fixes
+---------
+
+2.11.1
+^^^^^^
+
+- [KC-5909] - Synchronizing index entry and record writes
+
+2.11.2
+^^^^^^
+
+- [KX-839] - Added optional completeValue query parameter to /search/autocomplete/field endpoint
+
+2.11.3
+^^^^^^
+
+- [KC-5825] - Fix for importing Avro files


### PR DESCRIPTION
Merging 2.11 docs into 3.0 docs. The 3.0 branch has been neglected since we aren't updating the 3.0 code base