### PR TITLE
Fixing indexing-policy endpoint, and objectQuery.yaml parsing error

### DIFF
--- a/docs/source/api.yaml
+++ b/docs/source/api.yaml
@@ -1477,7 +1477,10 @@ parameters:
             included in records.
         limit:
           type: integer
-          description: The number of results to fetch in this call
+          description: >
+            The number of results to fetch in this call Note that the query
+            returns max of 20 records by default, if this parameter is not
+            specified.
         offset:
           type: integer
           description: The number of records in the result set to skip
@@ -1982,7 +1985,7 @@ paths:
             due to end of input'
           schema:
             $ref: '#/definitions/500servererror'
-  '/api/v1/data-sets/{dataSetId}/indexingPolicy':
+  '/api/v1/data-sets/{dataSetId}/indexing-policy':
     parameters:
       - $ref: '#/parameters/dataSetId'
     get:

--- a/open-api/api.yaml
+++ b/open-api/api.yaml
@@ -483,7 +483,7 @@ paths:
     $ref: paths/dataSetClearDataSet.yaml
   #/api/v1/data-sets/{dataSetId}/flatSchema:
   #  $ref: paths/dataSetFlatSchema.yaml
-  /api/v1/data-sets/{dataSetId}/indexingPolicy:
+  /api/v1/data-sets/{dataSetId}/indexing-policy:
     $ref: paths/dataSetIndexingPolicies.yaml
   /api/v1/data-sets/{dataSetId}/jobs:
     $ref: paths/dataSetJobs.yaml

--- a/open-api/schemas/objectQuery.yaml
+++ b/open-api/schemas/objectQuery.yaml
@@ -73,8 +73,9 @@ properties:
           all fields to be included in records.
   limit:
     type: integer
-    description: The number of results to fetch in this call
-    Note that the query returns max of 20 records by default, if this parameter is not specified.
+    description: >
+          The number of results to fetch in this call
+          Note that the query returns max of 20 records by default, if this parameter is not specified.
   offset:
     type: integer
     description: The number of records in the result set to skip


### PR DESCRIPTION
Includes fixes for ZD 2199, indexing-policy endpoint was incorrect for 3.2.x. Also fixing parsing error, stemming from the description not including ">" and expected spacing, when running 'npm run build' that existed in the open-api/schemas/objectQuery.yaml