### PR TITLE
Correcting /api/records end point parameter dataSetId

### DIFF
--- a/docs/source/api.yaml
+++ b/docs/source/api.yaml
@@ -2446,6 +2446,7 @@ paths:
         - Records
       parameters:
         - name: datasetId
+        - name: dataSetId
           type: string
           in: query
           required: true

--- a/docs/source/api.yaml
+++ b/docs/source/api.yaml
@@ -2445,7 +2445,6 @@ paths:
       tags:
         - Records
       parameters:
-        - name: datasetId
         - name: dataSetId
           type: string
           in: query

--- a/open-api/paths/records.yaml
+++ b/open-api/paths/records.yaml
@@ -6,7 +6,7 @@ get:
   operationId: getRecordById
   tags: ["Records"]
   parameters:
-    - name: datasetId
+    - name: dataSetId
       type: string
       in: query
       required: true


### PR DESCRIPTION
the parameter "dataSetId" was incorrectly shown as "datasetId" with a lower case "s" instead of an upper case "s". "dataSetId" is the correct parameter.