### PR TITLE
Fixing extra "recordId" parameter in records.yaml

### DIFF
--- a/docs/source/api.yaml
+++ b/docs/source/api.yaml
@@ -2449,10 +2449,6 @@ paths:
           type: string
           in: query
           required: true
-        - name: recordId
-          type: string
-          in: query
-          required: true
       description: >
         Get a single record by data set id and record id.
 

--- a/open-api/api.yaml
+++ b/open-api/api.yaml
@@ -1,6 +1,6 @@
 swagger: "2.0"
 info:
-  version: 2.9.0
+  version: 2.10.0
   title: Koverse REST API
   description: >
         Specification for interacting with the Koverse Rest API

--- a/open-api/paths/records.yaml
+++ b/open-api/paths/records.yaml
@@ -10,10 +10,6 @@ get:
       type: string
       in: query
       required: true
-    - name: recordId
-      type: string
-      in: query
-      required: true
   description: |
         Get a single record by data set id and record id.
 


### PR DESCRIPTION
the api/records end point was showing an extra "recordId" parameter. This removes that extra entry.

Also, the version info in api.yaml was still 2.9.0 even though this is for 2.10. This updates the version info to 2.10.