### PR TITLE
3.2 docs fixing extra "recordId" parameter in records.yaml

### DIFF
--- a/docs/source/api.yaml
+++ b/docs/source/api.yaml
@@ -2580,10 +2580,6 @@ paths:
           type: string
           in: query
           required: true
-        - name: recordId
-          type: string
-          in: query
-          required: true
       description: >
         Get a single record by data set id and record id. (Note: recordIds may
         have a delimiter that is not valid json)

--- a/open-api/paths/records.yaml
+++ b/open-api/paths/records.yaml
@@ -10,10 +10,6 @@ get:
       type: string
       in: query
       required: true
-    - name: recordId
-      type: string
-      in: query
-      required: true
   description: |
         Get a single record by data set id and record id. (Note: recordIds may have a delimiter that is not valid json)
 


### PR DESCRIPTION
In the 3.2 docs the api/records end point was showing an extra "recordId" parameter. This removes that extra entry in the 3.2 docs.