### PR TITLE
Kc 5978 update rest api status codes

### DIFF
--- a/open-api/api.yaml
+++ b/open-api/api.yaml
@@ -196,6 +196,8 @@ tags:
 definitions:
   500servererror:
     $ref: schemas/servererror.yaml
+  400servererror:
+    $ref: schemas/badrequest.yaml
   apiClient:
     $ref: schemas/apiClient.yaml
   dataSet:
@@ -563,9 +565,9 @@ paths:
     $ref: paths/transformId.yaml
   /api/v1/transforms/{transformId}/run-transform:
     $ref: paths/transformIdRunTransform.yaml
-  /api/v1/transforms/{transformId}/transform-schedules:
+  /api/v1/transforms/{transformId}/schedules:
     $ref: paths/transformIdSchedules.yaml
-  /api/v1/transforms/{transformId}/transform-schedules/{transformScheduleId}:
+  /api/v1/transforms/{transformId}/schedules/{transformScheduleId}:
     $ref: paths/transformIdScheduleId.yaml
   /api/v1/transform-types:
     $ref: paths/transformTypes.yaml

--- a/open-api/paths/dataSetAttributeNames.yaml
+++ b/open-api/paths/dataSetAttributeNames.yaml
@@ -31,7 +31,7 @@ get:
       #   - movie_title
       #   - plot_keywords
       #   - title_year
-    500:
+    400:
       description: If data set not found message will read 'Internal error processing getDataSetAttributeNames'
       schema:
-        $ref: "../api.yaml#/definitions/500servererror"
+        $ref: "../api.yaml#/definitions/400servererror"

--- a/open-api/paths/dataSetAttributes.yaml
+++ b/open-api/paths/dataSetAttributes.yaml
@@ -15,7 +15,7 @@ get:
         type: array
         items:
           $ref: "../api.yaml#/definitions/dataSetAttributes"
-    500:
+    400:
       description: If data set not found message will read 'Could not find database object in method...'
       schema:
-        $ref: "../api.yaml#/definitions/500servererror"
+        $ref: "../api.yaml#/definitions/400servererror"

--- a/open-api/paths/dataSetClearDataSet.yaml
+++ b/open-api/paths/dataSetClearDataSet.yaml
@@ -12,7 +12,7 @@ get:
   responses:
     200:
       description: '200 OK'
-    500:
+    400:
       description: If data set not found message will read 'No content to map to Object due to end of input'
       schema:
-        $ref: "../api.yaml#/definitions/500servererror"
+        $ref: "../api.yaml#/definitions/400servererror"

--- a/open-api/paths/dataSetId.yaml
+++ b/open-api/paths/dataSetId.yaml
@@ -15,10 +15,10 @@ get:
       description: Returns the data set metadata
       schema:
         $ref: "../api.yaml#/definitions/dataSetMetadata"
-    500:
+    400:
       description: Returns server error if no data set is found
       schema :
-        $ref: "../api.yaml#/definitions/500servererror"
+        $ref: "../api.yaml#/definitions/400servererror"
 
 put:
   summary: Update
@@ -43,7 +43,7 @@ delete:
       description: Returns the data set metadata with an updated DELETED dataset name.
       schema:
         $ref: "../api.yaml#/definitions/dataSetMetadata"
-    500:
+    400:
       description: If data set not found message will read 'No content to map to Object due to end of input'
       schema:
-        $ref: "../api.yaml#/definitions/500servererror"
+        $ref: "../api.yaml#/definitions/400servererror"

--- a/open-api/paths/dataSetIndexingPolicies.yaml
+++ b/open-api/paths/dataSetIndexingPolicies.yaml
@@ -12,6 +12,10 @@ get:
       description: Returns an array of the indexing policy metadata of a data set.
       schema:
         $ref: "../api.yaml#/definitions/dataSetIndexingPolicy"
+    400:
+      description: Returns 400 is dataset cannot be found
+      schema:
+        $ref: "../api.yaml#/definitions/400servererror"
 
 put:
   summary: Update

--- a/open-api/paths/dataSetRecords.yaml
+++ b/open-api/paths/dataSetRecords.yaml
@@ -26,7 +26,7 @@ get:
             items:
               $ref: "../api.yaml#/definitions/record"
     400:
-      description: Returns server error if no data set is found
+      description: Returns client error if no data set is found
       schema :
         $ref: "../api.yaml#/definitions/400servererror"
       # example:

--- a/open-api/paths/dataSetRecords.yaml
+++ b/open-api/paths/dataSetRecords.yaml
@@ -25,6 +25,10 @@ get:
             type: array
             items:
               $ref: "../api.yaml#/definitions/record"
+    400:
+      description: Returns server error if no data set is found
+      schema :
+        $ref: "../api.yaml#/definitions/400servererror"
       # example:
       #   flatSchema: true,
       #   records:

--- a/open-api/paths/dataSetRepair.yaml
+++ b/open-api/paths/dataSetRepair.yaml
@@ -12,7 +12,7 @@ get:
   responses:
     200:
       description: '200 OK'
-    500:
+    400:
       description: If data set not found message will read 'No content to map to Object due to end of input'
       schema:
-        $ref: "../api.yaml#/definitions/500servererror"
+        $ref: "../api.yaml#/definitions400servererror"

--- a/open-api/paths/importFlowId.yaml
+++ b/open-api/paths/importFlowId.yaml
@@ -16,7 +16,11 @@ get:
       #   last-modified:
       #     type: string
       #     description: The date/time that the import flow was last modified
-
+    400:
+      description: If import flow cannot be found failureMessage will read 'Could not find database object in method 'getImportFlowById' with arguments []'
+      schema:
+        $ref: "../api.yaml#/definitions400servererror"
+      
 delete:
   deprecated: true
   summary: Delete

--- a/open-api/paths/importFlowNormalizations.yaml
+++ b/open-api/paths/importFlowNormalizations.yaml
@@ -14,6 +14,11 @@ get:
         type: array
         items:
           $ref: "../api.yaml#/definitions/normalization"
+    400:
+      description: If import flow or normalization cannot be found failureMessage will read 'Could not find database object in method 'listNormalizationsByImportFlowId' with arguments []'
+      schema:
+        $ref: "../api.yaml#/definitions400servererror"
+  
 
 post:
   deprecated: true

--- a/open-api/paths/importFlowNormalizationsId.yaml
+++ b/open-api/paths/importFlowNormalizationsId.yaml
@@ -13,6 +13,10 @@ get:
       description: Returns the normalization data
       schema:
         $ref: "../api.yaml#/definitions/normalization"
+    400:
+      description: If import flow or normalization cannot be found failureMessage will read 'Could not find database object in method 'getNormalizationById' with arguments []'
+      schema:
+        $ref: "../api.yaml#/definitions400servererror"
 
 put:
   deprecated: true

--- a/open-api/paths/importScheduleId.yaml
+++ b/open-api/paths/importScheduleId.yaml
@@ -17,6 +17,10 @@ get:
       #   last-modified:
       #     type: string
       #     description: The date/time that the import schedule was last modified
+    400:
+      description: If import flow ID cannot be found.
+      schema:
+        $ref: "../api.yaml#/definitions400servererror"
 
 delete:
   deprecated: true

--- a/open-api/paths/queryObject.yaml
+++ b/open-api/paths/queryObject.yaml
@@ -60,6 +60,6 @@ post:
         items:
           $ref: "../api.yaml#/definitions/dataSetResult"
     400:
-      description: If data set not found message will read 'No content to map to Object due to end of input'
+      description: If query is malformed will show 400 error.
       schema:
         $ref: "../api.yaml#/definitions400servererror"

--- a/open-api/paths/queryObject.yaml
+++ b/open-api/paths/queryObject.yaml
@@ -59,3 +59,7 @@ post:
         type: array
         items:
           $ref: "../api.yaml#/definitions/dataSetResult"
+    400:
+      description: If data set not found message will read 'No content to map to Object due to end of input'
+      schema:
+        $ref: "../api.yaml#/definitions400servererror"

--- a/open-api/paths/queryObjectNames.yaml
+++ b/open-api/paths/queryObjectNames.yaml
@@ -59,3 +59,7 @@ post:
         type: array
         items:
           $ref: "../api.yaml#/definitions/dataSetResult"
+    400:
+      description: If query is malformed will show 400 error.
+      schema:
+        $ref: "../api.yaml#/definitions400servererror"

--- a/open-api/paths/records.yaml
+++ b/open-api/paths/records.yaml
@@ -33,10 +33,10 @@ get:
       #   flatSchema: true
       #   records:
       #     - $ref: "../schemas/recordExample.yaml"
-    500:
+    400:
       description: Returns server error if recordId or dataSetId are missing.
       schema:
-        $ref: "../api.yaml#/definitions/500servererror"
+        $ref: "../api.yaml#/definitions/400servererror"
 
 post:
   summary: Create

--- a/open-api/paths/transformId.yaml
+++ b/open-api/paths/transformId.yaml
@@ -16,6 +16,10 @@ get:
       #   last-modified:
       #     type: string
       #     description: The date/time that the transform was last modified
+    400:
+      description: Returns client error if no dataset is found.
+      schema :
+        $ref: "../api.yaml#/definitions/400servererror"
 
 delete:
   summary: Delete

--- a/open-api/paths/transforms.yaml
+++ b/open-api/paths/transforms.yaml
@@ -24,6 +24,10 @@ get:
         type: array
         items:
           $ref: "../api.yaml#/definitions/transform"
+    400:
+      description: If data set not found message will read 'Could not find database object in method 'listOutputDataSetTransforms' with arguments []'
+      schema:
+        $ref: "../api.yaml#/definitions400servererror"
 
 post:
   summary: Create

--- a/open-api/schemas/badrequest.yaml
+++ b/open-api/schemas/badrequest.yaml
@@ -1,0 +1,5 @@
+type: string
+description: >
+  An error has occurred.
+example:
+  400 Server Error, Request is malformed, please check input and resubmit.


### PR DESCRIPTION
Updated status codes from 500 to 400 for some end points, added 400 status codes to a large amount of get responses that could fail from a malformed client input.