### PR TITLE
KC-6288 updating python version for readthedocs build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ docs/npm-debug.log
 
 # node runtime
 node_modules/
+
+#python environments
+/venv

--- a/docs/source/readthedocs.yml
+++ b/docs/source/readthedocs.yml
@@ -18,6 +18,6 @@ formats: html
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.4
+  version: 3.5
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
<https://koverse.atlassian.net/browse/KC-6288>

## why does this matter?
The readthdocs build is failing with this error:

ERROR: Could not find a version that satisfies the requirement Pillow==7.2.0 (from -r docs/source/requirements.txt (line 16)) (from versions: 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7.0, 1.7.1, 1.7.2, 1.7.3, 1.7.4, 1.7.5, 1.7.6, 1.7.7, 1.7.8, 2.0.0, 2.1.0, 2.2.0, 2.2.1, 2.2.2, 2.3.0, 2.3.1, 2.3.2, 2.4.0, 2.5.0, 2.5.1, 2.5.2, 2.5.3, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.8.0, 2.8.1, 2.8.2, 2.9.0, 3.0.0, 3.1.0rc1, 3.1.0, 3.1.1, 3.1.2, 3.2.0, 3.3.0, 3.3.1, 3.3.2, 3.3.3, 3.4.0, 3.4.1, 3.4.2, 4.0.0, 4.1.0, 4.1.1, 4.2.0, 4.2.1, 4.3.0, 5.0.0, 5.1.0, 5.2.0, 5.3.0, 5.4.0, 5.4.1, 6.0.0, 6.1.0, 6.2.0, 6.2.1, 6.2.2)
ERROR: No matching distribution found for Pillow==7.2.0 (from -r docs/source/requirements.txt (line 16))

## what was impacted?
I updated the python version because Pillow 7.2.0 requires 3.5 is newer

## how do you know this works?
I don't yet. I need to build this on readthedocs.

## how does this make you feel?
😬