### PR TITLE
KC-6346

### DIFF
--- a/docs/source/usage/addons.rst
+++ b/docs/source/usage/addons.rst
@@ -1,0 +1,137 @@
+.. _addons:
+
+Addons
+======
+
+The following addons are packaged with Koverse
+
+Databases
+#########
+
+Sinks
+*****
+
+* MySQL
+* Oracle
+
+Sources
+*******
+
+* MS SQL Server
+* MySQL (MariaDB)
+* MySQL (MariaDB) Continuous
+* PostgreSQL
+* Oracle 11g 2
+* Oracle 11g 2 (Connection String)
+* Oracle RAC 11g 2
+* PostgreSQL Continuous
+
+Social Media
+############
+
+Sources
+*******
+
+* Twitter Streaming
+* Twitter Timeline
+
+File Systems
+############
+
+Sinks
+*****
+
+* File Transfer Protocol Server (FTP)
+* Hadoop Distributed File System (HDFS)
+* Amazon Simple Storage Service (S3)
+
+Sources
+*******
+
+* File Transfer Protocol Server (FTP)
+* Hadoop Distributed File System (HDFS)
+* Koverse File Upload (HDFS)
+* Amazon Simple Storage Service (S3)
+
+  * Requires AWS Access Key ID and Secret
+* Secure File Transfer Protocol Server (SFTP)
+* Google Drive
+
+   * Requires a Google Service Account https://support.google.com/a/answer/7378726?hl=en
+   * This user must have at least Drive https://www.googleapis.com/auth/drive and Drive File https://www.googleapis.com/auth/drive.file scopes
+   * Service Account must have access to the documents to be imported (share documents or folders with Service Account)
+
+
+E-Mail
+######
+
+Sources
+*******
+
+* Email Account (IMAP)
+
+Queues
+######
+
+Sinks
+*****
+* Kafka Queue
+
+Sources
+*******
+
+* Kafka Queue for Kafka version 2.0.0
+
+Web
+###
+
+Sources
+*******
+
+* Newsfeed Source
+* URL Source
+* All of Wikipedia
+* Wikipedia Pages
+
+Structured Data
+###############
+
+Structured Data Export
+######################
+
+Genomics
+########
+
+Transforms
+**********
+
+* Generate Protein Sequence N-Grams
+* Sequence Similarity
+
+Spark SQL
+#########
+
+Transforms
+**********
+
+* Spark SQL Transform
+* Spark Copy Transform
+
+Text
+####
+
+Transforms
+**********
+
+* Extract Keywords
+
+Time
+####
+
+H2O
+###
+
+Transforms
+**********
+
+* H2O Model Predictions

--- a/docs/source/usageguide.rst
+++ b/docs/source/usageguide.rst
@@ -20,3 +20,4 @@ Usage Guide
    usage/interactive.rst
    usage/access_control.rst
    usage/additional.rst
+   usage/addons.rst


### PR DESCRIPTION
Added addons section to Usage Guide with list of included addons
Added instructions for creating a Service Account for G Drive Source

<https://koverse.atlassian.net/browse/KC-6346>

## why does this matter?
Added list of addons packaged with Koverse. Specific addon documentation can be added here.

## what was impacted?
- sources.rst
- usageguide.rst

## how do you know this works?
Tested locally

## how does this make you feel?
<img width="1624" alt="Screen Shot 2020-09-09 at 3 59 14 PM" src="https://user-images.githubusercontent.com/6775097/92647915-adad3200-f2b6-11ea-8c22-267f4c77327c.png">

