### PR TITLE
Kc 6376 addon format

### DIFF
--- a/docs/source/usage/addons.rst
+++ b/docs/source/usage/addons.rst
@@ -65,6 +65,11 @@ Sources
 E-Mail
 ######
 
+Formats
+*******
+
+* mbox
+
 Sources
 *******
 
@@ -85,6 +90,13 @@ Sources
 Web
 ###
 
+Formats
+*******
+
+* html
+* htm
+* xhtml
+
 Sources
 *******
 
@@ -99,22 +111,30 @@ Structured Data
 Formats
 *******
 
-* Avro
-* EdiX13
-* MS Excel
-* GeoJSON
-* JSON
-* JSON Stream
-* Parquet
-* CSV
-* TSV
-* XML
+* avro
+* csv
+* edi
+* geo json
+* json
+* jsonstream
+* parquet
+* psv
+* tsv
+* txt (tab-separated)
+* xls
+* xlsx
+* xml
 
 Structured Data Export
 ######################
 
 Genomics
 ########
+
+Formats
+*******
+
+* fasta
 
 Transforms
 **********

--- a/docs/source/usage/addons.rst
+++ b/docs/source/usage/addons.rst
@@ -96,6 +96,20 @@ Sources
 Structured Data
 ###############
 
+Formats
+*******
+
+* Avro
+* EdiX13
+* MS Excel
+* GeoJSON
+* JSON
+* JSON Stream
+* Parquet
+* CSV
+* TSV
+* XML
+
 Structured Data Export
 ######################
 
@@ -119,6 +133,19 @@ Transforms
 
 Text
 ####
+
+MS Office, Text and PDF
+
+Formats
+*******
+
+* Vector Documents (pdf, eps, ai, ps)
+* MS Office (ppt, pptx, doc, docx, xls, xlsx, msg, pst)
+* Textual Documents (pub, wri, rtf, txt)
+* Web (css)
+* Images (jpg, jpeg, psd, bmp, bpg, png, gif, tiff)
+* Video (mp4, ogg, mov)
+* Audio (mp3, wav, aac, flac)
 
 Transforms
 **********


### PR DESCRIPTION
<https://koverse.atlassian.net/browse/KC-6376>

## why does this matter?
Added formats to Usage Guide -> Addons section of documentation

## what was impacted?
- addons.rst

## how do you know this works?
Tested locally, showed screenshots to Paul
<img width="563" alt="Screen Shot 2020-10-07 at 2 38 17 PM" src="https://user-images.githubusercontent.com/6775097/95390929-01f20480-08ab-11eb-81f2-cd9f3ca3ec41.png">
<img width="376" alt="Screen Shot 2020-10-07 at 2 37 38 PM" src="https://user-images.githubusercontent.com/6775097/95390969-0ae2d600-08ab-11eb-9f01-49f8b3d48558.png">



## how does this make you feel?
![expression gif](express_yourself.gif)
