### PR TITLE
KC-6332

### DIFF
--- a/docs/source/dev/analytics/pyspark_transform.rst
+++ b/docs/source/dev/analytics/pyspark_transform.rst
@@ -192,6 +192,13 @@ We can write a simple test program to try out our code on some example data. We'
 
       def testExtractSubjectSentiment(self):
           global text
+
+          # When runner.testOnLocalData is called with named=True, inputDatasets is a list of named inputDatasets
+          inputDatasets = {‘inputDataset’:[{‘text’: ‘This is a test Sentence’}]}
+          runner = PySparkTransformTestRunner({'textField': 'text'}, PySparkTransform)
+          output = runner.testOnLocalData(inputDatasets, named=True).collect()
+
+          # When runner.testOnLocalData is called without named (default value is false), inputDatasets is an array of records
           inputDatasets = [[{'inputDataset': text}]]
           runner = PySparkTransformTestRunner({'textField': 'text'}, PySparkTransform)
           output = runner.testOnLocalData(inputDatasets).collect()


### PR DESCRIPTION
Added documentation for calling runner.testOnLocalData() with named inputDatasets

<https://koverse.atlassian.net/browse/KC-6332>

## why does this matter?
Added example of calling runner.testOnLocalData() with named inputDatasets

## what was impacted?
- pyspark_transform.rst

## how do you know this works?
Tested with and without named input datasets

## how does this make you feel?
![expression gif](express_yourself.gif)
