### PR TITLE
Add csvparser fix to 3.0.5 releasenotes

### DIFF
--- a/docs/source/releasenotes/add-ons/3.0.rst
+++ b/docs/source/releasenotes/add-ons/3.0.rst
@@ -29,6 +29,11 @@ Bug Fixes
 ^^^^^
 - [KC-6340] - CSV parser doesn't have support for multiline values
 
+3.0.5
+^^^^^
+
+- [KC-6380] - CSV Parser Incorrectly Parsing Pipe-delimited file
+
 
 
 


### PR DESCRIPTION
Just adding the csv parser fix to the addon release notes