### PR TITLE
KDP-65 …

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -7,6 +7,9 @@ Release Notes
 .. toctree::
   :maxdepth: 1
 
+  releasenotes/3.9.rst
+  releasenotes/3.8.rst
+  releasenotes/3.7.rst
   releasenotes/3.6.rst
   releasenotes/3.5.rst
   releasenotes/3.4.rst


### PR DESCRIPTION
this is why the releasenotes are missing for versionsion 3.7 through 3.9

<https://koverse.atlassian.net/browse/KDP-65>
