### PR TITLE
KDP-104 …

### DIFF
--- a/docs/source/dev/integration/field_maskers.rst
+++ b/docs/source/dev/integration/field_maskers.rst
@@ -5,6 +5,8 @@ Field Maskers
 
 Koverse supports applying policies for obfuscating the values in certain fields for particular groups of users. This capability allows data owners to use fine-grained controls to protect sensitive information as required by company policies or privacy regulations such as HIPAA and GDPR. The obfuscation logic is provided by custom code extensions to Koverse called Field Maskers.
 
+All masked fields will be removed while processing a transform unless the transform owner has access to view those fields unmasked.
+
 A Field Masker takes a single value and returns an obfuscated value.
 
 To create a custom Field Masker simply create a class that implements the FieldMasker interface.

--- a/docs/source/usage/access_control.rst
+++ b/docs/source/usage/access_control.rst
@@ -63,10 +63,10 @@ To make a data set available to everyone, simply add the 'Everyone' group to the
 Masking Specific Data Set Attributes
 ------------------------------------
 
-Koverse allows data set owners to mask specific attributes so that their values are not visible in search results or downloads. This enables organizations to protect sensitive values, such as personally identifiable information, in order to comply with privacy policies and regulations such as HIPAA and GDPR.
+Koverse allows data set owners to mask specific attributes so that their values are not visible in search results, transforms generated from the configured data set, or downloads. This enables organizations to protect sensitive values, such as personally identifiable information, in order to comply with privacy policies and regulations such as HIPAA and GDPR.
 
 To edit a data set's masking settings click on the Data tab on the left navigation menu and select the data set you want.
-Click on the Settings tab and then the Masking tab.
+Click on the Settings tab and then the Masking tab. Please note: all masked fields will be removed when using the data set for a transform unless the transform owner has permission to view those fields. This is true regardless of the masking type selected.
 
 .. image:: /_static/UsageGuide/masking.png
 
@@ -97,7 +97,7 @@ Now, users in the 'Administrators' group will see hashed values instead of emplo
 
 If we were to add 'Administrators' to the list of excepted groups for this second 'SHA hasher' masker we would again see the unprotected employee names. When there are one or more maskers applied to an field, the first masker that a user is not excluded from will take effect. This way data can be masked differently for different user groups, allowing for a wide variety of data protection policies to be enforced.
 
-It is important to note that while values are masked in search results and downloads from the Koverse UI and REST API, values of masked attributes are not masked when the data set is processed in transforms or exported to external systems via a Koverse export. For this reason, the ability to export and transform data should be restricted when using masking.
+It is important to note that while values are masked in search results and downloads from the Koverse UI and REST API, values of masked attributes are not masked when the data set is exported to external systems via a Koverse export. For this reason, the ability to export data should be restricted when using masking.
 
 Also note that users who are not able to see masked values may still perform searches for a value that is masked and get results, albeit with the masked values still masked in results. If searches should not be performed on values of a masked field the field can be excluded from being indexed, thereby preventing searching on masked values.
 


### PR DESCRIPTION
Updated text referencing transforms and masking to remove remarks about transforms not having masking. Updated masking overview text to include transform masking.

<https://koverse.atlassian.net/browse/KDP-104>

## why does this matter?
Masked fields will now be removed when processing a transform but only if the transform creator/owner isn't authorized to view those fields unmasked. The documentation for 3.9 and beyond need to reflect this.

This will be merged into main then merged into 3.9 from main.