### PR TITLE
KDP-556 Update release notes for 3.9.2

### DIFF
--- a/docs/source/releasenotes/3.9.rst
+++ b/docs/source/releasenotes/3.9.rst
@@ -23,3 +23,11 @@ Bug Fixes
 Bug Fixes
 ---------
 - [KDP-156] Fix for /tmp directory filling up and crashing KDP
+
+3.9.2
+^^^^^
+- Add-ons version: 3.0.7
+
+Bug Fixes
+---------
+- [KDP-423] Fixed issue with data catalog list. Now if user has data catalog permission they can see disabled list items in the dataset list. If not, they can only see the datasets they own or belong to.


### PR DESCRIPTION
<https://koverse.atlassian.net/browse/KDP-556>

## why does this matter?
New kdp classic release requires updated release notes with changes included.

## what was impacted?
- 3.9 release notes in main. After PR is merged then I will merge this change into the 3.9documentation branch for publishing to readthedocs
