### PR TITLE
Sprint52 kdp 556 merge into 3.9

### DIFF
--- a/docs/source/releasenotes/3.9.rst
+++ b/docs/source/releasenotes/3.9.rst
@@ -23,3 +23,11 @@ Bug Fixes
 Bug Fixes
 ---------
 - [KDP-156] Fix for /tmp directory filling up and crashing KDP
+
+3.9.2
+^^^^^
+- Add-ons version: 3.0.7
+
+Bug Fixes
+---------
+- [KDP-423] Fixed issue with data catalog list. Now if user has data catalog permission they can see disabled list items in the dataset list. If not, they can only see the datasets they own or belong to.

--- a/docs/source/releasenotes/3.9.rst
+++ b/docs/source/releasenotes/3.9.rst
@@ -30,4 +30,5 @@ Bug Fixes
 
 Bug Fixes
 ---------
+- [KDP-158] Update Koverse start up to not rerun any updates that have already been run.
 - [KDP-423] Fixed issue with data catalog list. Now if user has data catalog permission they can see disabled list items in the dataset list. If not, they can only see the datasets they own or belong to.


### PR DESCRIPTION
<https://koverse.atlassian.net/browse/KDP-556>

## why does this matter?
Updating 3.9 with release notes for publishing to readthedocs