### PR TITLE
KDP-2424 forgot to link release notes page

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -7,6 +7,8 @@ Release Notes
 .. toctree::
   :maxdepth: 1
 
+  releasenotes/3.11.rst
+  releasenotes/3.10.rst
   releasenotes/3.9.rst
   releasenotes/3.8.rst
   releasenotes/3.7.rst


### PR DESCRIPTION
<https://koverse.atlassian.net/browse/KDP-2424>

## why does this matter?
The release notes link should show up for the last 2 releases on the main release notes page.

The actual release notes pages are already there.

